### PR TITLE
Move plugin

### DIFF
--- a/Move-Plugin/Template.cshtml
+++ b/Move-Plugin/Template.cshtml
@@ -1,0 +1,95 @@
+@{
+    var querySelector = Model.querySelector == "custom" ? Model.queryValue : string.Format("{0}{1}",
+    Model.querySelector, Model.queryValue);
+    var editMode = Model.editMode!=null ? Model.editMode.ToString().ToLower() : "false";
+    var moveTop = Model.moveTop != null ? Model.moveTop.ToString().ToLower() : "false";
+    var moveLeft = Model.moveLeft != null ? Model.moveLeft.ToString().ToLower() : "false";
+    var moveRight = Model.moveRight != null ? Model.moveRight.ToString().ToLower() : "false";
+    var moveDown = Model.moveDown != null ? Model.moveDown.ToString().ToLower() : "false";
+}
+
+<script type="text/javascript">
+    function adjustWidgetPosition() {
+        // Check if you are in DNN edit mode
+        var isEditMode = false;
+
+        if (@editMode) {
+            isEditMode = document.body.classList.contains("dnnEditState");
+        }
+        // Find all iframes (in case there are multiple ones)
+        var widgets = document.querySelectorAll('@querySelector');
+
+        widgets.forEach(function (widget) {
+            if (widget) {
+                if (@Model.modType== 1) {
+                    //Hide the widget
+                    if(@editMode){
+                        if(isEditMode){
+                            widget.style.display = 'none';
+                        }
+                    }else{
+                         widget.style.display = 'none';
+                    }
+                   
+                } else {
+                    //Move the widget
+                    if (isEditMode) {
+                        if (@moveTop) {
+                            widget.style.top = isEditMode ? '@Model.newTop' : '@Model.currentTop';
+                        }
+                        if (@moveLeft) {
+                            widget.style.left = isEditMode ? '@Model.newLeft' : '@Model.currentLeft';
+                        }
+                        if (@moveRight) {
+                            widget.style.right = isEditMode ? '@Model.newRight' : '@Model.currentRight';
+                        }
+                        if (@moveDown) {
+                            widget.style.bottom = isEditMode ? '@Model.newBottom' : '@Model.currentBottom';
+                        }
+                    } else {
+                        if (@moveTop) {
+                            widget.style.top = '@Model.newTop';
+                        }
+                        if (@moveLeft) {
+                            widget.style.left = '@Model.newLeft';
+                        }
+                        if (@moveRight) {
+                            widget.style.right = '@Model.newRight';
+                        }
+                        if (@moveDown) {
+                            widget.style.bottom = '@Model.newBottom';
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Start a continuous check interval
+    var checkInterval = setInterval(function () {
+        // Check if we are no longer on the page
+        if (!document.body) {
+            clearInterval(checkInterval);
+            return;
+        }
+
+        // Try to adjust the position
+        adjustWidgetPosition();
+    }, 1000); // Check every second
+
+    // Execute the function when the page loads
+    window.addEventListener('load', adjustWidgetPosition);
+
+    // Watch for DOM changes to handle dynamic changes
+    var observer = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                adjustWidgetPosition();
+            }
+        });
+    });
+    observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+
+    // Listener for window size changes (sometimes helps with dynamic rendering)
+    window.addEventListener('resize', adjustWidgetPosition);
+</script>

--- a/Move-Plugin/builder.json
+++ b/Move-Plugin/builder.json
@@ -1,0 +1,293 @@
+{
+  "formfields": [
+    {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "querySelector",
+      "title": "Query Selector",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "#",
+          "text": "Id"
+        },
+        {
+          "value": ".",
+          "text": "Class"
+        },
+        {
+          "value": "custom",
+          "text": "Custom"
+        }
+      ],
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "default": "#",
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "queryValue",
+      "title": "Value",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "editMode",
+      "title": "Only in DNN edit mode?",
+      "fieldtype": "checkbox",
+      "advanced": false
+    },
+    {
+      "fieldname": "modType",
+      "title": "Modification Type:",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "1",
+          "text": "Hidden"
+        },
+        {
+          "value": "2",
+          "text": "Move Position"
+        }
+      ],
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "default": "1",
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "moveTop",
+      "title": "Move up?",
+      "fieldtype": "checkbox",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "modType",
+          "values": "2"
+        }
+      ]
+    },
+    {
+      "fieldname": "currentTop",
+      "title": "Current Value:",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveTop",
+          "values": "true"
+        },
+        {
+          "fieldname": "editMode",
+          "values": "true"
+        }
+      ]
+    },
+    {
+      "fieldname": "newTop",
+      "title": "New Value:",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveTop",
+          "values": "true"
+        }
+      ]
+    },
+    {
+      "fieldname": "moveLeft",
+      "title": "Move Left?",
+      "fieldtype": "checkbox",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "modType",
+          "values": "2"
+        }
+      ]
+    },
+    {
+      "fieldname": "currentLeft",
+      "title": "Current Value:",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveLeft",
+          "values": "true"
+        },
+        {
+          "fieldname": "editMode",
+          "values": "true"
+        }
+      ]
+    },
+    {
+      "fieldname": "newLeft",
+      "title": "New Value:",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveLeft",
+          "values": "true"
+        }
+      ]
+    },
+    {
+      "fieldname": "moveRight",
+      "title": "Move Right?",
+      "fieldtype": "checkbox",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "modType",
+          "values": "2"
+        }
+      ]
+    },
+    {
+      "fieldname": "currentRight",
+      "title": "Current Value:",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveRight",
+          "values": "true"
+        },
+        {
+          "fieldname": "editMode",
+          "values": "true"
+        }
+      ]
+    },
+    {
+      "fieldname": "newRight",
+      "title": "New Value",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveRight",
+          "values": "true"
+        }
+      ]
+    },
+    {
+      "fieldname": "moveDown",
+      "title": "Move Down?",
+      "fieldtype": "checkbox",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "modType",
+          "values": "2"
+        }
+      ]
+    },
+    {
+      "fieldname": "currentBottom",
+      "title": "Current Value",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveDown",
+          "values": "true"
+        },
+        {
+          "fieldname": "editMode",
+          "values": "true"
+        }
+      ]
+    },
+    {
+      "fieldname": "newBottom",
+      "title": "New Value:",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": [
+        {
+          "fieldname": "moveDown",
+          "values": "true"
+        }
+      ]
+    }
+  ],
+  "formtype": "object"
+}

--- a/Move-Plugin/data.json
+++ b/Move-Plugin/data.json
@@ -1,0 +1,3 @@
+{
+  "ModuleTitle": "move-plugin"
+}

--- a/Move-Plugin/options.json
+++ b/Move-Plugin/options.json
@@ -1,0 +1,138 @@
+{
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "querySelector": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "Id",
+        "Class",
+        "Custom"
+      ]
+    },
+    "queryValue": {
+      "type": "text"
+    },
+    "editMode": {
+      "type": "checkbox"
+    },
+    "modType": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "Hidden",
+        "Move Position"
+      ]
+    },
+    "moveTop": {
+      "type": "checkbox",
+      "dependencies": {
+        "modType": [
+          "2"
+        ]
+      }
+    },
+    "currentTop": {
+      "type": "text",
+      "dependencies": {
+        "moveTop": [
+          "true"
+        ],
+        "editMode": [
+          "true"
+        ]
+      }
+    },
+    "newTop": {
+      "type": "text",
+      "dependencies": {
+        "moveTop": [
+          "true"
+        ]
+      }
+    },
+    "moveLeft": {
+      "type": "checkbox",
+      "dependencies": {
+        "modType": [
+          "2"
+        ]
+      }
+    },
+    "currentLeft": {
+      "type": "text",
+      "dependencies": {
+        "moveLeft": [
+          "true"
+        ],
+        "editMode": [
+          "true"
+        ]
+      }
+    },
+    "newLeft": {
+      "type": "text",
+      "dependencies": {
+        "moveLeft": [
+          "true"
+        ]
+      }
+    },
+    "moveRight": {
+      "type": "checkbox",
+      "dependencies": {
+        "modType": [
+          "2"
+        ]
+      }
+    },
+    "currentRight": {
+      "type": "text",
+      "dependencies": {
+        "moveRight": [
+          "true"
+        ],
+        "editMode": [
+          "true"
+        ]
+      }
+    },
+    "newRight": {
+      "type": "text",
+      "dependencies": {
+        "moveRight": [
+          "true"
+        ]
+      }
+    },
+    "moveDown": {
+      "type": "checkbox",
+      "dependencies": {
+        "modType": [
+          "2"
+        ]
+      }
+    },
+    "currentBottom": {
+      "type": "text",
+      "dependencies": {
+        "moveDown": [
+          "true"
+        ],
+        "editMode": [
+          "true"
+        ]
+      }
+    },
+    "newBottom": {
+      "type": "text",
+      "dependencies": {
+        "moveDown": [
+          "true"
+        ]
+      }
+    }
+  }
+}

--- a/Move-Plugin/schema.json
+++ b/Move-Plugin/schema.json
@@ -1,0 +1,135 @@
+{
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "querySelector": {
+      "type": "string",
+      "title": "Query Selector",
+      "enum": [
+        "#",
+        ".",
+        "custom"
+      ],
+      "default": "#",
+      "required": true
+    },
+    "queryValue": {
+      "type": "string",
+      "title": "Value",
+      "required": true
+    },
+    "editMode": {
+      "type": "boolean",
+      "title": "Only in DNN edit mode?"
+    },
+    "modType": {
+      "type": "string",
+      "title": "Modification Type:",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "default": "1",
+      "required": true
+    },
+    "moveTop": {
+      "type": "boolean",
+      "title": "Move up?",
+      "dependencies": [
+        "modType"
+      ]
+    },
+    "currentTop": {
+      "type": "string",
+      "title": "Current Value:",
+      "required": true,
+      "dependencies": [
+        "moveTop",
+        "editMode"
+      ]
+    },
+    "newTop": {
+      "type": "string",
+      "title": "New Value:",
+      "required": true,
+      "dependencies": [
+        "moveTop"
+      ]
+    },
+    "moveLeft": {
+      "type": "boolean",
+      "title": "Move Left?",
+      "dependencies": [
+        "modType"
+      ]
+    },
+    "currentLeft": {
+      "type": "string",
+      "title": "Current Value:",
+      "required": true,
+      "dependencies": [
+        "moveLeft",
+        "editMode"
+      ]
+    },
+    "newLeft": {
+      "type": "string",
+      "title": "New Value:",
+      "required": true,
+      "dependencies": [
+        "moveLeft"
+      ]
+    },
+    "moveRight": {
+      "type": "boolean",
+      "title": "Move Right?",
+      "dependencies": [
+        "modType"
+      ]
+    },
+    "currentRight": {
+      "type": "string",
+      "title": "Current Value:",
+      "required": true,
+      "dependencies": [
+        "moveRight",
+        "editMode"
+      ]
+    },
+    "newRight": {
+      "type": "string",
+      "title": "New Value",
+      "required": true,
+      "dependencies": [
+        "moveRight"
+      ]
+    },
+    "moveDown": {
+      "type": "boolean",
+      "title": "Move Down?",
+      "dependencies": [
+        "modType"
+      ]
+    },
+    "currentBottom": {
+      "type": "string",
+      "title": "Current Value",
+      "required": true,
+      "dependencies": [
+        "moveDown",
+        "editMode"
+      ]
+    },
+    "newBottom": {
+      "type": "string",
+      "title": "New Value:",
+      "required": true,
+      "dependencies": [
+        "moveDown"
+      ]
+    }
+  }
+}

--- a/Move-Plugin/view.json
+++ b/Move-Plugin/view.json
@@ -1,0 +1,25 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "querySelector": "#pos_1_1",
+      "queryValue": "#pos_1_1",
+      "editMode": "#pos_1_1",
+      "modType": "#pos_1_1",
+      "moveTop": "#pos_1_1",
+      "currentTop": "#pos_1_1",
+      "newTop": "#pos_1_1",
+      "moveLeft": "#pos_1_1",
+      "currentLeft": "#pos_1_1",
+      "newLeft": "#pos_1_1",
+      "moveRight": "#pos_1_1",
+      "currentRight": "#pos_1_1",
+      "newRight": "#pos_1_1",
+      "moveDown": "#pos_1_1",
+      "currentBottom": "#pos_1_1",
+      "newBottom": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR introduces the `Move-Plugin` Template, a reusable template for OpenContent that allows modifying the position and visibility of third-party iframes (such as chat buttons or other external plugins injected via scripts).

### Features:  
- Allows configuring custom selectors to identify specific iframes (e.g., by ID, class, attributes, etc.).  
- Enables applying modifications in both normal mode and DNN edit mode.  
- Dynamically detects iframes and adjusts their `top`, `left`, `right`, or `bottom` properties based on configured options.  
- Adds the option to hide selected iframes in edit mode.  
- Ensures flexibility by allowing configuration through OpenContent settings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Locally tested in a DNN development environment with multiple third-party plugins (chat buttons, support widgets, etc.).
- Verified that iframes are correctly detected and repositioned according to the set configuration.
- Confirmed that the hide option works properly.
- Ensured that there are no conflicts with other OpenContent templates.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.