### PR TITLE
Typo in some template's top margin settings

### DIFF
--- a/Porto-Image/template-schema.json
+++ b/Porto-Image/template-schema.json
@@ -5,13 +5,13 @@
             "title": "Margin (top)",
             "type": "string",
             "enum": [
-				"pt-0",
-				"pt-1",
-				"pt-2",
-				"pt-3",
-				"pt-4",
-				"pt-5",
-				"pt-auto"
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
             ]
         },
         "MarginBottom": {

--- a/Porto-Paragraphs-Side-Image/template-schema.json
+++ b/Porto-Paragraphs-Side-Image/template-schema.json
@@ -5,13 +5,13 @@
             "title": "Margin (top)",
             "type": "string",
             "enum": [
-				"pt-0",
-				"pt-1",
-				"pt-2",
-				"pt-3",
-				"pt-4",
-				"pt-5",
-				"pt-auto"
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
             ]
         },
         "MarginBottom": {

--- a/Porto-Paragraphs/template-schema.json
+++ b/Porto-Paragraphs/template-schema.json
@@ -5,13 +5,13 @@
             "title": "Margin (top)",
             "type": "string",
             "enum": [
-				"pt-0",
-				"pt-1",
-				"pt-2",
-				"pt-3",
-				"pt-4",
-				"pt-5",
-				"pt-auto"
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
             ]
         },
         "MarginBottom": {


### PR DESCRIPTION
Resolves an issue where the top margin wasn't going to be applied in the new templates. 