### PR TITLE
Adds top & bottom settings for margins & padding

### DIFF
--- a/Porto-Call-To-Action/Template-data.json
+++ b/Porto-Call-To-Action/Template-data.json
@@ -1,0 +1,6 @@
+{
+    "MarginTop": "mt-auto" , 
+    "MarginBottom": "mb-auto",
+    "PaddingTop": "pt-auto",
+    "PaddingBottom": "pb-auto"
+}

--- a/Porto-Call-To-Action/Template.cshtml
+++ b/Porto-Call-To-Action/Template.cshtml
@@ -10,6 +10,10 @@
     var isButtonCentered = Model.Style == "ButtonCentered";
     var isFullWidth = Model.Style == "FullWidth";
     var isFooter = Model.Style == "Footer";
+    var marginTop = (!string.IsNullOrEmpty(Model.Settings.MarginTop)) ? Model.Settings.MarginTop : "mt-0";
+    var marginBottom = (!string.IsNullOrEmpty(Model.Settings.MarginBottom)) ? Model.Settings.MarginBottom : "mb-0";
+    var paddingTop = (!string.IsNullOrEmpty(Model.Settings.PaddingTop)) ? Model.Settings.PaddingTop : "pt-0";
+    var paddingBottom = (!string.IsNullOrEmpty(Model.Settings.PaddingBottom)) ? Model.Settings.PaddingBottom : "pb-0";
 
     var buttonClass = isColors || isSmall || isFullWidth ? "btn-default" : "btn-primary";
     var sectionClass = "call-to-action mb-xl" +
@@ -22,7 +26,8 @@
     (isSmall ? " button-centered" : "") +
     (isFullWidth ? " " + Model.Color : "") +
     (isFooter ? " call-to-action-default with-button-arrow call-to-action-in-footer" : "") +
-    (isAnimated ? " data-appear-animation='fadeIn'" : "");
+    (isAnimated ? " data-appear-animation='fadeIn'" : "") + 
+    (" " + marginTop) + (" " + marginBottom) + (" " + paddingTop) + (" " + paddingBottom);
 }
 
 @if (isParallax)
@@ -106,3 +111,8 @@ else
         }
     </section>
 }
+@*
+<div class="dnnClear">
+    @ObjectInfo.Print(Model)
+</div>
+*@

--- a/Porto-Call-To-Action/builder.json
+++ b/Porto-Call-To-Action/builder.json
@@ -3,7 +3,10 @@
     {
       "fieldname": "Heading",
       "title": "Heading Text (required)",
-      "fieldtype": "wysihtml",
+      "fieldtype": "ckeditor",
+      "ckeditoroptions": {
+        "configset": "basic"
+      },
       "advanced": true,
       "required": false,
       "hidden": false,
@@ -15,7 +18,10 @@
     {
       "fieldname": "SubHeading",
       "title": "Heading Subtitle",
-      "fieldtype": "wysihtml",
+      "fieldtype": "ckeditor",
+      "ckeditoroptions": {
+        "configset": "basic"
+      },
       "advanced": false
     },
     {

--- a/Porto-Call-To-Action/options.json
+++ b/Porto-Call-To-Action/options.json
@@ -1,10 +1,12 @@
 {
   "fields": {
     "Heading": {
-      "type": "wysihtml"
+      "type": "ckeditor",
+      "configset": "basic"
     },
     "SubHeading": {
-      "type": "wysihtml"
+      "type": "ckeditor",
+      "configset": "basic"
     },
     "Button": {
       "type": "text"

--- a/Porto-Call-To-Action/template-options.json
+++ b/Porto-Call-To-Action/template-options.json
@@ -1,0 +1,61 @@
+{
+	"fields": {		
+		"MarginTop": {
+			"title": "Margin (top)",
+			"type": "select",
+			"optionLabels": [
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
+			],
+			"removeDefaultNone": true
+		},		
+		"MarginBottom": {
+			"title": "Margin (bottom)",
+			"type": "select",
+			"optionLabels": [
+				"mb-0",
+				"mb-1",
+				"mb-2",
+				"mb-3",
+				"mb-4",
+				"mb-5",
+				"mb-auto"
+			],
+			"removeDefaultNone": true
+		},
+		"PaddingTop": {
+			"title": "Padding (top)",
+			"type": "select",
+			"optionLabels": [
+				"pt-0",
+				"pt-1",
+				"pt-2",
+				"pt-3",
+				"pt-4",
+				"pt-5",
+				"pt-auto"
+			],
+			"removeDefaultNone": true
+		},
+		"PaddingBottom": {
+			"title": "Padding (bottom)",
+			"type": "select",
+			"optionLabels": [
+				"pb-0",
+				"pb-1",
+				"pb-2",
+				"pb-3",
+				"pb-4",
+				"pb-5",
+				"pb-auto"
+			],
+			"removeDefaultNone": true
+		}	
+
+	}
+}

--- a/Porto-Call-To-Action/template-schema.json
+++ b/Porto-Call-To-Action/template-schema.json
@@ -1,0 +1,57 @@
+{
+    "type": "object",
+    "properties": {        
+        "MarginTop": {
+            "title": "Margin (top)",
+            "type": "string",
+            "enum": [
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
+            ]
+        },
+        "MarginBottom": {
+            "title": "Margin (bottom)",
+            "type": "string",
+            "enum": [
+				"mb-0",
+				"mb-1",
+				"mb-2",
+				"mb-3",
+				"mb-4",
+				"mb-5",
+				"mb-auto"
+            ]
+        },
+        "PaddingTop": {
+            "title": "Padding (top)",
+            "type": "string",
+            "enum": [
+				"pt-0",
+				"pt-1",
+				"pt-2",
+				"pt-3",
+				"pt-4",
+				"pt-5",
+				"pt-auto"
+            ]
+        },
+        "PaddingBottom": {
+            "title": "Padding (bottom)",
+            "type": "string",
+            "enum": [
+				"pb-0",
+				"pb-1",
+				"pb-2",
+				"pb-3",
+				"pb-4",
+				"pb-5",
+				"pb-auto"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
- Adds new template settings for adding top/bottom margin and/or padding.   
- Also adds a commented-out troubleshooting snippet at the bottom of the template  
- Switches the rich text editor to `ckeditor` (`basic`)  