### PR TITLE
Adds a link target option to CTA

### DIFF
--- a/Porto-Call-To-Action/Template.cshtml
+++ b/Porto-Call-To-Action/Template.cshtml
@@ -14,6 +14,7 @@
     var marginBottom = (!string.IsNullOrEmpty(Model.Settings.MarginBottom)) ? Model.Settings.MarginBottom : "mb-0";
     var paddingTop = (!string.IsNullOrEmpty(Model.Settings.PaddingTop)) ? Model.Settings.PaddingTop : "pt-0";
     var paddingBottom = (!string.IsNullOrEmpty(Model.Settings.PaddingBottom)) ? Model.Settings.PaddingBottom : "pb-0";
+    var linkTarget = (!string.IsNullOrEmpty(Model.LinkTarget)) ? Model.LinkTarget : "_self";
 
     var buttonClass = isColors || isSmall || isFullWidth ? "btn-default" : "btn-primary";
     var sectionClass = "call-to-action mb-xl" +
@@ -43,7 +44,7 @@
                             <p>@Model.SubHeading</p>
                         </div>
                         <div class="call-to-action-btn">
-                            <a href="@Model.ButtonLink" target="_blank" class="btn btn-lg btn-primary">@Model.Button</a>
+                            <a href="@Model.ButtonLink" target="@linkTarget" class="btn btn-lg btn-primary">@Model.Button</a>
                         </div>
                     </div>
                 </div>
@@ -62,7 +63,7 @@ else if (isSmall)
                         <p>@Model.SubHeading</p>
                     </div>
                     <div class="call-to-action-btn">
-                        <a href="@Model.ButtonLink" target="_blank" class="btn btn-lg @buttonClass">@Model.Button</a>
+                        <a href="@Model.ButtonLink" target="@linkTarget" class="btn btn-lg @buttonClass">@Model.Button</a>
                     </div>
                 </section>
             </section>
@@ -82,7 +83,7 @@ else
                             <p>@Model.SubHeading</p>
                         </div>
                         <div class="call-to-action-btn">
-                            <a href="@Model.ButtonLink" target="_blank" class="btn btn-lg @buttonClass">@Model.Button</a>
+                            <a href="@Model.ButtonLink" target="@linkTarget" class="btn btn-lg @buttonClass">@Model.Button</a>
                             @if (isFooter)
                             {
                                 <span class="arrow hlb hidden-xs hidden-sm hidden-md" data-appear-animation="rotateInUpLeft"
@@ -101,7 +102,7 @@ else
                 <p>@Model.SubHeading</p>
             </div>
             <div class="call-to-action-btn">
-                <a href="@Model.ButtonLink" target="_blank" class="btn btn-lg @buttonClass">@Model.Button</a>
+                <a href="@Model.ButtonLink" target="@linkTarget" class="btn btn-lg @buttonClass">@Model.Button</a>
                 @if (isWithArrow)
                 {
                     <span class="arrow hlb hidden-xs hidden-sm hidden-md" data-appear-animation="rotateInUpLeft"

--- a/Porto-Call-To-Action/builder.json
+++ b/Porto-Call-To-Action/builder.json
@@ -44,6 +44,36 @@
       "dependencies": []
     },
     {
+      "fieldname": "LinkTarget",
+      "title": "Link Target",
+      "fieldtype": "select",
+      "fieldoptions": [
+        {
+          "value": "_blank",
+          "text": "New Tab"
+        },
+        {
+          "value": "_self",
+          "text": "Self"
+        },
+        {
+          "value": "_parent",
+          "text": "Parent"
+        },
+        {
+          "value": "_top",
+          "text": "Top"
+        }
+      ],
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "default": "_self",
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Style",
       "title": "Style",
       "fieldtype": "select",

--- a/Porto-Call-To-Action/options.json
+++ b/Porto-Call-To-Action/options.json
@@ -15,6 +15,16 @@
       "type": "text",
       "placeholder": "Example: https://github.com/UpendoVentures/OpenContentTemplates"
     },
+    "LinkTarget": {
+      "type": "select",
+      "sort": false,
+      "optionLabels": [
+        "New Tab",
+        "Self",
+        "Parent",
+        "Top"
+      ]
+    },
     "Style": {
       "type": "select",
       "sort": false,

--- a/Porto-Call-To-Action/schema.json
+++ b/Porto-Call-To-Action/schema.json
@@ -17,6 +17,17 @@
       "type": "string",
       "title": "Button Link"
     },
+    "LinkTarget": {
+      "type": "string",
+      "title": "Link Target",
+      "enum": [
+        "_blank",
+        "_self",
+        "_parent",
+        "_top"
+      ],
+      "default": "_blank"
+    },
     "Style": {
       "type": "string",
       "title": "Style",

--- a/Porto-Call-To-Action/view.json
+++ b/Porto-Call-To-Action/view.json
@@ -7,6 +7,7 @@
       "SubHeading": "#pos_1_1",
       "Button": "#pos_1_1",
       "ButtonLink": "#pos_1_1",
+      "LinkTarget": "#pos_1_1",
       "Style": "#pos_1_1",
       "WithBorders": "#pos_1_1",
       "Featured": "#pos_1_1",


### PR DESCRIPTION
# Template: Porto-Call-to-Action
- Adds a new field to allow a link target to be specified.  
- Removes the hard-coded `target="_blank"` attribute and replaces it with `target="@Model.LinkTarget"` instead.  