### PR TITLE
Features/paragraph side image updates

### DIFF
--- a/Porto-Paragraphs-Side-Image/Template-data.json
+++ b/Porto-Paragraphs-Side-Image/Template-data.json
@@ -1,4 +1,5 @@
 {
+    "ImagePosition": "right",
     "MarginTop": "mt-auto", 
     "MarginBottom": "mb-auto",
     "PaddingTop": "pt-auto",

--- a/Porto-Paragraphs-Side-Image/Template.cshtml
+++ b/Porto-Paragraphs-Side-Image/Template.cshtml
@@ -1,24 +1,42 @@
 <div class="container">
     <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
-        <div class="col-md-8">
-            @if (Model.Paragraph != null)
-            {
-                @Html.Raw(Model.Paragraph)
-            }
-            else
-            {
-                <!-- No Paragraph Found -->
-            }
-        </div>
-        <div class="col-md-4">
-            @if (Model.Image != null)
-            {
-                <img src="@Model.Image" alt="@Model.AltText" title="@Model.AltText" class="z-1 @Model.Classes" />
-            }
-            else
-            {
-                <!-- No Image Found -->
-            }
-        </div>
+        @if ((Model.Settings.ImagePosition ?? "right").ToLower() == "left")
+        {
+            @RenderImageColumn()
+            @RenderTextColumn()
+        }
+        else
+        {
+            @RenderTextColumn()
+            @RenderImageColumn()
+        }
     </div>
 </div>
+
+@helper RenderImageColumn()
+{
+    <div class="col-md-4">
+        @if (Model.Image != null)
+        {
+            <img src="@Model.Image" alt="@Model.AltText" title="@Model.AltText" class="z-1 @Model.Classes" />
+        }
+        else
+        {
+            <!-- No Image Found -->
+        }
+    </div>
+}
+
+@helper RenderTextColumn()
+{
+    <div class="col-md-8">
+        @if (Model.Paragraph != null)
+        {
+            @Html.Raw(Model.Paragraph)
+        }
+        else
+        {
+            <!-- No Paragraph Found -->
+        }
+    </div>
+}

--- a/Porto-Paragraphs-Side-Image/builder.json
+++ b/Porto-Paragraphs-Side-Image/builder.json
@@ -19,7 +19,9 @@
       "fieldname": "Image",
       "title": "Image (required)",
       "fieldtype": "image",
-      "imageoptions": {},
+      "imageoptions": {
+        "folder": "Images"
+      },
       "advanced": true,
       "required": true,
       "hidden": false,

--- a/Porto-Paragraphs-Side-Image/options.json
+++ b/Porto-Paragraphs-Side-Image/options.json
@@ -5,10 +5,15 @@
       "configset": "basic"
     },
     "Image": {
-      "type": "image"
+      "type": "image",
+      "uploadfolder": "Images",
+      "typeahead": {
+        "Folder": "Images"
+      }
     },
     "Classes": {
-      "type": "text"
+      "type": "text",
+      "placeholder": "img-fluid"
     },
     "AltText": {
       "type": "text",

--- a/Porto-Paragraphs-Side-Image/template-options.json
+++ b/Porto-Paragraphs-Side-Image/template-options.json
@@ -1,5 +1,14 @@
 {
 	"fields": {		
+		"ImagePosition": {
+			"title": "Image Position",
+			"type": "select",
+			"optionLabels": [
+				"Right",
+				"Left"
+			],
+			"removeDefaultNone": true
+		},		
 		"MarginTop": {
 			"title": "Margin (top)",
 			"type": "select",

--- a/Porto-Paragraphs-Side-Image/template-schema.json
+++ b/Porto-Paragraphs-Side-Image/template-schema.json
@@ -1,7 +1,14 @@
 {
     "type": "object",
     "properties": {        
-        "MarginTop": {
+        "ImagePosition": {
+			"title": "Image Position",
+			"type": "string",
+			"enum": [
+				"Right",
+				"Left"
+			]
+		},"MarginTop": {
             "title": "Margin (top)",
             "type": "string",
             "enum": [


### PR DESCRIPTION
# Porto-Paragraphs-Side-Image  
- Added a new tetmplate setting to specify if the side image should be on the left or right (default right)  
- Added a placeholder to the Classes field for usability  
- Updated the Images folder to be the default image upload location.  
- Updated the template to use the new setting without duplicating code  