### PR TITLE
Create Porto-ExtensionList

### DIFF
--- a/Porto-ExtensionList/Template.cshtml
+++ b/Porto-ExtensionList/Template.cshtml
@@ -1,0 +1,141 @@
+@functions {
+    public string TruncateString(string description, int maxLength)
+    {
+        if (string.IsNullOrEmpty(description))
+        {
+            return string.Empty;
+        }
+
+        return description.Length > maxLength
+        ? description.Substring(0, maxLength).Trim() + "..."
+        : description.Trim();
+    }
+    public string GetCategoryLabel(string key)
+    {
+        var labels = new Dictionary<string, string>
+        {
+            { "devtool", "Developer" },
+            { "dnnmodule", "Module" },
+            { "dnnprompt", "Prompt" },
+            { "dnnprovider", "Provider" },
+            { "dnnjob", "Scheduled" },
+            { "dnnux", "User Experience" },
+            { "opensource", "Open-Source" },
+            { "commercial", "Commercial" }
+        };
+
+        return labels.ContainsKey(key) ? labels[key] : key;
+    }
+}
+@{
+    var categoriesArray = new List<string>();
+
+    if (Model.Extensions != null)
+    {
+        foreach (var item in Model.Extensions)
+        {
+            if (item.Category != null)
+            {
+                foreach (var category in item.Category)
+                {
+                    if (!categoriesArray.Contains(category))
+                    {
+                        categoriesArray.Add(category);
+                    }
+                }
+            }
+        }
+    }    
+
+    // Retrieve settings from the model
+    var columns = Model.Settings.Columns ?? "4";
+    var marginTop = Model.Settings.MarginTop ?? "mt-auto";
+    var marginBottom = Model.Settings.MarginBottom ?? "mb-auto";
+    var paddingTop = Model.Settings.PaddingTop ?? "pt-auto";
+    var paddingBottom = Model.Settings.PaddingBottom ?? "pb-auto";
+
+    // Combine classes for container styling
+    var containerClasses = string.Format("{0} {1} {2} {3}", marginTop, marginBottom, paddingTop, paddingBottom);
+}
+<div class="container @containerClasses">
+    <div class="row">      
+        <ul class="nav nav-pills sort-source" data-sort-id="portfolio" data-option-key="filter">
+            <li data-option-value="*" class="nav-item active">
+                <a class="nav-link" href="#">Show All</a>
+            </li>
+            @foreach (var category in categoriesArray)
+            {
+                <li data-option-value=".@category" class="nav-item">
+                    <a class="nav-link" href="#" style="color: #0077b3;">
+                    @GetCategoryLabel(category)            
+                    </a>
+                </li>
+            }
+        </ul>
+    </div>
+    <hr/>
+    @if (Model.Extensions != null)
+    {        
+        <div class="row">
+            <ul class="row image-gallery sort-destination lightbox" data-sort-id="portfolio"
+            data-plugin-options="{'delegate': 'a', 'type': 'image', 'gallery': {'enabled': true}}">                
+            @foreach (var item in Model.Extensions)
+                {
+                <li class="col-lg-@columns col-md-4 col-sm-6 col-xs-12 isotope-item @string.Join(" ", item.Category ?? new List<string>())">
+                    <div class="thumb-info thumb-info-hide-wrapper-bg mb-xlg d-flex flex-column flex-grow-1" style="min-height: 415px;">
+                        <span class="thumb-info-wrapper">
+                            <a href="@item.Download">
+                                <span class="thumb-info-wrapper d-flex align-items-center justify-content-center">
+                                    <img alt="@item.Title" title="@item.Title" src="@item.logo" class="img-fluid"
+                                        style="height: 200px; object-fit: cover;">
+                                </span>
+                                <span class="thumb-info-title">
+                                    <span class="thumb-info-inner">@item.Title</span>
+                                    <span class="thumb-info-type">
+                                        @foreach (var category in item.Category)
+                                        {                                            
+                                            <span class="badge badge-lg badge-primary">@GetCategoryLabel(category)</span>                                            
+                                        }
+                                    </span>
+                                </span>
+                            </a>
+                        </span>
+                        <div class="thumb-info-caption flex-grow-1 p-0">
+                            <span class="thumb-info-caption-text p-0"
+                                style="text-overflow: ellipsis; display: block; font-size: unset">
+                                @TruncateString(item.Description, 211)
+                            </span>
+                        </div>
+                        <hr class="m-1"/>                       
+                        <div class="d-flex justify-content-around mb-2 mt-2">
+                            <div class="pull-left">
+                                @if(@item.BadgeText != null)
+                                {
+                                    <span class="badge badge-success" style="font-size: unset">@item.BadgeText</span>
+                                }
+                            </div>
+                            <div class="pull-right">
+                                 <a href="@item.HomePage" target="_blank" class="btn btn-sm btn-primary rounded-circle">
+                                    <i class="fa fa-home"></i>
+                                </a>
+                                <a href="@item.Download" target="_blank" class="btn btn-sm btn-primary rounded-circle">
+                                    <i class="fa-solid fa-cloud-arrow-down"></i>
+                                </a>                               
+                            </div>
+                        </div>
+                    </div>
+                </li>
+            }
+            </ul>
+        </div>         
+    }
+    else
+    {
+        <div class="col-12">
+            <div class="dnnFormMessage info">
+                <h4>No Extensions Found</h4>
+                <p>Please add extensions to display them here.</p>
+            </div>
+        </div>
+    }
+</div>

--- a/Porto-ExtensionList/builder.json
+++ b/Porto-ExtensionList/builder.json
@@ -1,0 +1,127 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Extensions",
+      "title": "Extensions",
+      "fieldtype": "accordion",
+      "subfields": [
+        {
+          "fieldname": "Title",
+          "title": "Title",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Description",
+          "title": "Description",
+          "fieldtype": "ckeditor",
+          "ckeditoroptions": {
+            "configset": "basic"
+          },
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Category",
+          "title": "Category(ies)",
+          "fieldtype": "multicheckbox",
+          "fieldoptions": [
+            {
+              "value": "devtool",
+              "text": "Developer "
+            },
+            {
+              "value": "dnnmodule",
+              "text": "Module"
+            },
+            {
+              "value": "dnnprompt",
+              "text": "Prompt"
+            },
+            {
+              "value": "dnnprovider",
+              "text": "Provider"
+            },
+            {
+              "value": "dnnjob",
+              "text": "Scheduled "
+            },
+            {
+              "value": "dnnux",
+              "text": "User Experience"
+            },
+            {
+              "value": "opensource",
+              "text": "Open-Source"
+            },
+            {
+              "value": "commercial",
+              "text": "Commercial"
+            }
+          ],
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Homepage",
+          "title": "Home Page",
+          "fieldtype": "url",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Download",
+          "title": "Download",
+          "fieldtype": "url",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Logo",
+          "title": "Logo",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "BadgeText",
+          "title": "Badge text",
+          "fieldtype": "text",
+          "advanced": false
+        }
+      ],
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-ExtensionList/data.json
+++ b/Porto-ExtensionList/data.json
@@ -1,0 +1,52 @@
+{
+  "Extensions": [
+    {
+      "Title": "DNN Prompt",
+      "Description": "A command-line interface for managing DNN sites.",
+      "Category": [
+        "Prompt",
+        "Open-Source"
+      ],
+      "Homepage": "https://example.com/dnn-prompt",
+      "Download": "https://example.com/dnn-prompt/download",
+      "Logo": "https://example.com/images/dnn-prompt-logo.png",
+      "BadgeText":"open-source"
+    },
+    {
+      "Title": "DNN Module Creator",
+      "Description": "A tool for creating custom DNN modules quickly.",
+      "Category": [
+        "Module",
+        "Developer"
+      ],
+      "Homepage": "https://example.com/dnn-module-creator",
+      "Download": "https://example.com/dnn-module-creator/download",
+      "Logo": "https://example.com/images/dnn-module-creator-logo.png",
+      "BadgeText": "open-source"
+    },
+    {
+      "Title": "DNN UX Enhancer",
+      "Description": "Enhance the user experience of your DNN site.",
+      "Category": [
+        "Commercial",
+        "Commercial"
+      ],
+      "Homepage": "https://example.com/dnn-ux-enhancer",
+      "Download": "https://example.com/dnn-ux-enhancer/download",
+      "Logo": "https://example.com/images/dnn-ux-enhancer-logo.png",
+      "BadgeText": "open-source"
+    },
+    {
+      "Title": "Open Source Scheduler",
+      "Description": "A job scheduler for DNN with open-source support.",
+      "Category": [
+        "Open-Source",
+        "Open-Source"
+      ],
+      "Homepage": "https://example.com/open-source-scheduler",
+      "Download": "https://example.com/open-source-scheduler/download",
+      "Logo": "https://example.com/images/open-source-scheduler-logo.png",
+      "BadgeText": "open-source"
+    }
+  ]
+}

--- a/Porto-ExtensionList/options.json
+++ b/Porto-ExtensionList/options.json
@@ -1,0 +1,44 @@
+{
+  "fields": {
+    "Extensions": {
+      "type": "accordion",
+      "items": {
+        "fields": {
+          "Title": {
+            "type": "text"
+          },
+          "Description": {
+            "type": "ckeditor",
+            "configset": "basic"
+          },
+          "Category": {
+            "type": "checkbox",
+            "sort": false,
+            "optionLabels": [
+              "Developer",
+              "Module",
+              "Prompt",
+              "Provider",
+              "Scheduled",
+              "User Experience",
+              "Open-Source",
+              "Commercial"
+            ]
+          },
+          "Homepage": {
+            "type": "url"
+          },
+          "Download": {
+            "type": "url"
+          },
+          "Logo": {
+            "type": "text"
+          },
+          "BadgeText": {
+            "type": "text"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-ExtensionList/schema.json
+++ b/Porto-ExtensionList/schema.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "properties": {
+    "Extensions": {
+      "type": "array",
+      "title": "Extensions",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Title": {
+            "type": "string",
+            "title": "Title",
+            "required": true
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description",
+            "required": true
+          },
+          "Category": {
+            "type": "array",
+            "title": "Category(ies)",
+            "enum": [
+              "devtool",
+              "dnnmodule",
+              "dnnprompt",
+              "dnnprovider",
+              "dnnjob",
+              "dnnux",
+              "opensource",
+              "commercial"
+            ],
+            "optionLabels": [
+              "Developer",
+              "Module",
+              "Prompt",
+              "Provider",
+              "Scheduled",
+              "User Experience",
+              "Open-Source",
+              "Commercial"
+            ],
+            "default": "devtool",
+            "required": true
+          },
+          "Homepage": {
+            "type": "string",
+            "title": "Home Page",
+            "required": true
+          },
+          "Download": {
+            "type": "string",
+            "title": "Download",
+            "required": true
+          },
+          "Logo": {
+            "type": "string",
+            "title": "Logo",
+            "required": true
+          },
+          "BadgeText": {
+            "type": "string",
+            "title": "Badge text"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-ExtensionList/template-options.json
+++ b/Porto-ExtensionList/template-options.json
@@ -1,0 +1,70 @@
+{
+  "fields": {
+    "Columns": {
+      "title": "Columns",
+      "type": "select",
+      "enum": ["6","4","3","2"
+      ],
+      "optionLabels": [
+        "6",
+        "4",
+        "3",
+        "2"
+      ],
+      "removeDefaultNone": true
+    },
+    "Margin (top)": {
+      "title": "Margin (top)",
+      "type": "select",
+      "optionLabels": [
+        "mt-0", 
+        "mt-1", 
+        "mt-2", 
+        "mt-3",
+        "mt-4",
+        "mt-5",
+        "mt-auto"],
+      "removeDefaultNone": true
+    },
+    "Margin (bottom)": {
+      "title": "Margin (bottom)",
+      "type": "select",
+      "optionLabels": [
+        "mb-0",
+        "mb-1",
+        "mb-2",
+        "mb-3",
+        "mb-4",
+        "mb-5",
+        "mb-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "Padding (top)": {
+      "title": "Padding (top)",
+      "type": "select",
+      "optionLabels": [
+        "pt-0",
+        "pt-1",
+        "pt-2",
+        "pt-3",
+        "pt-4",
+        "pt-5",
+        "pt-auto"],
+      "removeDefaultNone": true
+    },
+    "Padding (bottom)": {
+      "title": "Padding (bottom)",
+      "type": "select",
+      "optionLabels": [
+        "pb-0",
+        "pb-1",
+        "pb-2",
+        "pb-3",
+        "pb-4",
+        "pb-5",
+        "pb-auto"],
+      "removeDefaultNone": true
+    }
+  }
+}

--- a/Porto-ExtensionList/template-schema.json
+++ b/Porto-ExtensionList/template-schema.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {  
+    "Columns": {
+      "title": "Columns",
+      "type": "select",
+      "enum": ["2", "3", "4", "6"],
+      "removeDefaultNone": true
+    },
+    "MarginTop": {
+      "title": "Margin (top)",
+      "type": "select",
+      "enum": ["mt-0", "mt-1", "mt-2", "mt-3", "mt-4", "mt-5", "mt-auto"],
+      "removeDefaultNone": true
+    },
+    "MarginBottom": {
+      "title": "Margin (bottom)",
+      "type": "select",
+      "enum": ["mb-0", "mb-1", "mb-2", "mb-3", "mb-4", "mb-5", "mb-auto"],
+      "removeDefaultNone": true
+    },
+    "PaddingTop": {
+      "title": "Padding (top)",
+      "type": "select",
+      "enum": ["pt-0", "pt-1", "pt-2", "pt-3", "pt-4", "pt-5", "pt-auto"],
+      "removeDefaultNone": true
+    },
+    "PaddingBottom": {
+      "title": "Padding (bottom)",
+      "type": "select",
+      "enum": ["pb-0", "pb-1", "pb-2", "pb-3", "pb-4", "pb-5", "pb-auto"],
+      "removeDefaultNone": true
+    }
+  }
+}

--- a/Porto-ExtensionList/view.json
+++ b/Porto-ExtensionList/view.json
@@ -1,0 +1,9 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "Extensions": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
## Description
This update introduces the new `Porto-ExtensionList` Razor.
- Categories for filtering and display are now dynamically generated based on OpenContent data.
- Category labels are mapped from stored values using a centralized `GetCategoryLabel` method.
- The dictionary-based approach ensures easier maintenance: new categories can be added by simply updating the mapping.
- All cards now have a consistent visual size, with fixed-height descriptions and scaled images to preserve layout consistency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Verified proper loading of extension data and categories from the database.
- Tested UI responsiveness and layout consistency with varying data.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6414b414-5c2a-475d-8c1d-1f7fef323002)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.