### PR TITLE
Module title fields

### DIFF
--- a/Porto-Alerts/Template.cshtml
+++ b/Porto-Alerts/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="alert @Model.Settings.Color @Model.Settings.Size">
     @if (Model.Settings.Dismissible ?? false)
     {

--- a/Porto-Alerts/builder.json
+++ b/Porto-Alerts/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Title",
       "title": "Title",
       "fieldtype": "text",

--- a/Porto-Alerts/options.json
+++ b/Porto-Alerts/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Title": {
       "type": "text"
     },

--- a/Porto-Alerts/schema.json
+++ b/Porto-Alerts/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Title": {
       "type": "string",
       "title": "Title"

--- a/Porto-Alerts/view.json
+++ b/Porto-Alerts/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div><div class=\"row\"><div class=\"col-md-4\" id=\"pos_2_1\"></div><div class=\"col-md-4\" id=\"pos_2_2\"></div><div class=\"col-md-4\" id=\"pos_2_3\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Title": "#pos_1_1",
       "Content": "#pos_1_1",
       "Icon": "#pos_1_1",

--- a/Porto-Animations/Template.cshtml
+++ b/Porto-Animations/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <p>
     <img alt="@Model.Settings.Animation"
         class="appear-animation pull-left @Model.Settings.Animation appear-animation-visible"

--- a/Porto-Animations/builder.json
+++ b/Porto-Animations/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Image",
       "title": "Image (optional)",
       "fieldtype": "image",

--- a/Porto-Animations/options.json
+++ b/Porto-Animations/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Image": {
       "type": "image"
     },

--- a/Porto-Animations/schema.json
+++ b/Porto-Animations/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Image": {
       "type": "string",
       "title": "Image (optional)",

--- a/Porto-Animations/view.json
+++ b/Porto-Animations/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Image": "#pos_1_1",
       "Items": "#pos_1_1"
     }

--- a/Porto-Arrows/Template.cshtml
+++ b/Porto-Arrows/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <section class="call-to-action with-borders with-button-arrow mb-xl">
   <div class="call-to-action-content">
     @if(Model.Content != null)

--- a/Porto-Arrows/builder.json
+++ b/Porto-Arrows/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Content",
       "title": "Content Text (required)",
       "fieldtype": "ckeditor",

--- a/Porto-Arrows/options.json
+++ b/Porto-Arrows/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Content": {
       "type": "ckeditor"
     },

--- a/Porto-Arrows/schema.json
+++ b/Porto-Arrows/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Content": {
       "type": "string",
       "title": "Content Text (required)"

--- a/Porto-Arrows/view.json
+++ b/Porto-Arrows/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Content": "#pos_1_1",
       "Buttom": "#pos_1_1",
       "Arrow": "#pos_1_1",

--- a/Porto-Before-After/Template.cshtml
+++ b/Porto-Before-After/Template.cshtml
@@ -2,6 +2,10 @@
     var settings = Model.Settings;
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (settings.Style == "Default")
 {
     <div class="row align-items-center">

--- a/Porto-Before-After/builder.json
+++ b/Porto-Before-After/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Heading",
       "title": "Heading Text (required)",
       "fieldtype": "text",

--- a/Porto-Before-After/options.json
+++ b/Porto-Before-After/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Heading": {
       "type": "text"
     },

--- a/Porto-Before-After/schema.json
+++ b/Porto-Before-After/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Heading": {
       "type": "string",
       "title": "Heading Text (optional)"

--- a/Porto-Blockquotes/Template.cshtml
+++ b/Porto-Blockquotes/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @foreach (var item in Model.Items)
 {
     <div class="row">

--- a/Porto-Blockquotes/builder.json
+++ b/Porto-Blockquotes/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Blockquotes",
       "title": "Blockquotes",
       "fieldtype": "text",

--- a/Porto-Blockquotes/options.json
+++ b/Porto-Blockquotes/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Blockquotes": {
       "type": "text"
     },

--- a/Porto-Blockquotes/schema.json
+++ b/Porto-Blockquotes/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Blockquotes": {
       "type": "string",
       "title": "Blockquotes"

--- a/Porto-Blockquotes/view.json
+++ b/Porto-Blockquotes/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Blockquotes": "#pos_1_1",
       "Items": "#pos_1_1"
     }

--- a/Porto-Buttons/Template.cshtml
+++ b/Porto-Buttons/Template.cshtml
@@ -5,6 +5,10 @@
     rel = string.IsNullOrEmpty(rel) ? string.Empty : string.Format("rel=\"{0}\"", rel);
     target = string.IsNullOrEmpty(target) ? string.Empty : string.Format("target=\"{0}\"", target);
 }
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="container">
     <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
         <div class="col-md-12">

--- a/Porto-Buttons/builder.json
+++ b/Porto-Buttons/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Button",
       "title": "Button Text (required)",
       "fieldtype": "text",

--- a/Porto-Buttons/options.json
+++ b/Porto-Buttons/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Button": {
       "type": "text"
     },

--- a/Porto-Buttons/schema.json
+++ b/Porto-Buttons/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Button": {
       "type": "string",
       "title": "Button Text (required)"

--- a/Porto-Buttons/view.json
+++ b/Porto-Buttons/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Button": "#pos_1_1",
       "Icon": "#pos_1_1",
       "Link": "#pos_1_1",

--- a/Porto-Call-To-Action/Template.cshtml
+++ b/Porto-Call-To-Action/Template.cshtml
@@ -31,6 +31,11 @@
     (" " + marginTop) + (" " + marginBottom) + (" " + paddingTop) + (" " + paddingBottom);
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
+
 @if (isParallax)
 {
     <section class="parallax section section-text-light section-parallax" data-plugin-options="{'speed': 1.5}"

--- a/Porto-Call-To-Action/builder.json
+++ b/Porto-Call-To-Action/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Heading",
       "title": "Heading Text (required)",
       "fieldtype": "ckeditor",

--- a/Porto-Call-To-Action/options.json
+++ b/Porto-Call-To-Action/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Heading": {
       "type": "ckeditor",
       "configset": "basic"

--- a/Porto-Call-To-Action/schema.json
+++ b/Porto-Call-To-Action/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Heading": {
       "type": "string",
       "title": "Heading Text (required)"

--- a/Porto-Call-To-Action/view.json
+++ b/Porto-Call-To-Action/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Heading": "#pos_1_1",
       "SubHeading": "#pos_1_1",
       "Button": "#pos_1_1",

--- a/Porto-Carousel/Template.cshtml
+++ b/Porto-Carousel/Template.cshtml
@@ -2,6 +2,10 @@
     var style = Model.Settings.Style != null ? Model.Settings.Style.ToString() : string.Empty;
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @switch ((string)style)
 {
     case "FullWidth":

--- a/Porto-Carousel/builder.json
+++ b/Porto-Carousel/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "InnerTopText",
       "title": "Inner Top Text (Only InsideText true)",
       "fieldtype": "textarea",

--- a/Porto-Carousel/options.json
+++ b/Porto-Carousel/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "InnerTopText": {
       "type": "textarea"
     },

--- a/Porto-Carousel/schema.json
+++ b/Porto-Carousel/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "InnerTopText": {
       "type": "string",
       "title": "Inner Top Text (Only InsideText true)"

--- a/Porto-Carousel/view.json
+++ b/Porto-Carousel/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "InnerTopText": "#pos_1_1",
       "ItemsInnerText": "#pos_1_1",
       "Items": "#pos_1_1",

--- a/Porto-Countdowns/Template.cshtml
+++ b/Porto-Countdowns/Template.cshtml
@@ -4,6 +4,11 @@
   var parallaxImage = Model.ParallaxImage;
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
+
 @if (countdownStyle == "parallax")
 {
   <section class="parallax section section-text-light section-parallax section-center mt-none"

--- a/Porto-Countdowns/builder.json
+++ b/Porto-Countdowns/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "DateTime",
       "title": "DateTime (required)",
       "fieldtype": "text",

--- a/Porto-Countdowns/options.json
+++ b/Porto-Countdowns/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "DateTime": {
       "type": "text",
       "placeholder": "Use Format Year/Month/Day Hour:Minutes/Seconds"

--- a/Porto-Countdowns/schema.json
+++ b/Porto-Countdowns/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "DateTime": {
       "type": "string",
       "title": "DateTime (required)",

--- a/Porto-Counters/Template.cshtml
+++ b/Porto-Counters/Template.cshtml
@@ -8,6 +8,11 @@
   var inline = Model.Inline; 
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
+
 @if (style == "Default")
 {
   if (!withBackground)

--- a/Porto-Counters/builder.json
+++ b/Porto-Counters/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Style",
       "title": "Style",
       "fieldtype": "select",

--- a/Porto-Counters/options.json
+++ b/Porto-Counters/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Style": {
       "type": "select",
       "sort": false,

--- a/Porto-Counters/schema.json
+++ b/Porto-Counters/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Style": {
       "type": "string",
       "title": "Style",

--- a/Porto-Counters/view.json
+++ b/Porto-Counters/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Style": "#pos_1_1",
       "WithBorders": "#pos_1_1",
       "WithBackground": "#pos_1_1",

--- a/Porto-Dividers/Template.cshtml
+++ b/Porto-Dividers/Template.cshtml
@@ -4,6 +4,11 @@
     var enableAnimations = Model.Settings.EnableAnimations ?? false;
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
+
 @if (dividerType == "Divider with Icon")
 {
     <div class="divider 

--- a/Porto-Dividers/builder.json
+++ b/Porto-Dividers/builder.json
@@ -1,6 +1,25 @@
 {
     "formfields": [
       {
+        "fieldname": "ModuleTitle",
+        "title": "Module Title",
+        "fieldtype": "text",
+        "advanced": false
+      },
+      {
+        "fieldname": "ModuleAnchor",
+        "title": "Module Anchor",
+        "fieldtype": "text",
+        "advanced": true,
+        "required": false,
+        "hidden": false,
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "multilanguage": false,
+        "index": false,
+        "position": "1col1",
+        "dependencies": []
+      },
+      {
         "fieldname": "Icon",
         "title": "Icon (optional)",
         "fieldtype": "text",

--- a/Porto-Dividers/options.json
+++ b/Porto-Dividers/options.json
@@ -1,5 +1,13 @@
 {
     "fields": {
+      "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
       "Icon": {
         "type": "text"
       }

--- a/Porto-Dividers/schema.json
+++ b/Porto-Dividers/schema.json
@@ -1,7 +1,15 @@
 {
     "type": "object",
     "properties": {
-      
+      "ModuleTitle": {
+        "type": "string",
+        "title": "Module Title"
+      },
+      "ModuleAnchor": {
+        "type": "string",
+        "title": "Module Anchor",
+         "pattern": "^[a-zA-Z0-9\\-]+$"
+      },
       "Icon": {
         "type": "string",
         "title": "Icon (optional) - Example: fab fa-android",

--- a/Porto-ExtensionList/Template.cshtml
+++ b/Porto-ExtensionList/Template.cshtml
@@ -57,6 +57,10 @@
     // Combine classes for container styling
     var containerClasses = string.Format("{0} {1} {2} {3}", marginTop, marginBottom, paddingTop, paddingBottom);
 }
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="container @containerClasses">
     <div class="row">      
         <ul class="nav nav-pills sort-source" data-sort-id="portfolio" data-option-key="filter">

--- a/Porto-ExtensionList/builder.json
+++ b/Porto-ExtensionList/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Extensions",
       "title": "Extensions",
       "fieldtype": "accordion",

--- a/Porto-ExtensionList/options.json
+++ b/Porto-ExtensionList/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Extensions": {
       "type": "accordion",
       "items": {

--- a/Porto-ExtensionList/schema.json
+++ b/Porto-ExtensionList/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Extensions": {
       "type": "array",
       "title": "Extensions",

--- a/Porto-ExtensionList/view.json
+++ b/Porto-ExtensionList/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Extensions": "#pos_1_1"
     }
   }

--- a/Porto-Forms/Template.cshtml
+++ b/Porto-Forms/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div type="post">
     @foreach (var item in Model.Items)
     {

--- a/Porto-Forms/builder.json
+++ b/Porto-Forms/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "FormTitle",
       "title": "Form Title (required)",
       "fieldtype": "text",

--- a/Porto-Forms/options.json
+++ b/Porto-Forms/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "FormTitle": {
       "type": "text"
     },

--- a/Porto-Forms/schema.json
+++ b/Porto-Forms/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "FormTitle": {
       "type": "string",
       "title": "Form Title (required)",

--- a/Porto-Forms/view.json
+++ b/Porto-Forms/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "FormTitle": "#pos_1_1",
       "ButtonText": "#pos_1_1",
       "Items": "#pos_1_1"

--- a/Porto-Headings/Template.cshtml
+++ b/Porto-Headings/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="container">
     <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
     @if (Model.Settings.EnableHeadingBorder)

--- a/Porto-Headings/builder.json
+++ b/Porto-Headings/builder.json
@@ -1,6 +1,25 @@
 {
     "formfields": [
       {
+        "fieldname": "ModuleTitle",
+        "title": "Module Title",
+        "fieldtype": "text",
+        "advanced": false
+      },
+      {
+        "fieldname": "ModuleAnchor",
+        "title": "Module Anchor",
+        "fieldtype": "text",
+        "advanced": true,
+        "required": false,
+        "hidden": false,
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "multilanguage": false,
+        "index": false,
+        "position": "1col1",
+        "dependencies": []
+      },
+      {
         "fieldname": "Heading",
         "title": "Heading Text (required)",
         "fieldtype": "wysihtml",

--- a/Porto-Headings/options.json
+++ b/Porto-Headings/options.json
@@ -1,8 +1,18 @@
 {
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Heading": {
       "type": "wysihtml"
     },
     "SubHeading": {
       "type": "text"
-    }   
+    }
   }
+}

--- a/Porto-Headings/schema.json
+++ b/Porto-Headings/schema.json
@@ -1,6 +1,15 @@
 {
     "type": "object",
     "properties": {
+      "ModuleTitle": {
+        "type": "string",
+        "title": "Module Title"
+      },
+      "ModuleAnchor": {
+        "type": "string",
+        "title": "Module Anchor",
+         "pattern": "^[a-zA-Z0-9\\-]+$"
+      },
       "Heading": {
         "type": "string",
         "title": "Heading Text (required)",

--- a/Porto-Icon-Boxes/Template.cshtml
+++ b/Porto-Icon-Boxes/Template.cshtml
@@ -4,7 +4,10 @@
     return value != null && value.ToString().ToLower() == "true";
   }
 }
-
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Settings.IconBoxesType == "Classic")
 {
     <div class="featured-boxes @Model.Settings.FeaturedBoxesStyle">

--- a/Porto-Icon-Boxes/builder.json
+++ b/Porto-Icon-Boxes/builder.json
@@ -7,6 +7,19 @@
       "advanced": false
     },
     {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Items",
       "title": "Content Items",
       "fieldtype": "array",

--- a/Porto-Icon-Boxes/options.json
+++ b/Porto-Icon-Boxes/options.json
@@ -1,7 +1,12 @@
 {
   "fields": {
-    "ModuleTitle": {
+   "ModuleTitle": {
       "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
     },
     "Items": {
       "type": "array",

--- a/Porto-Icon-Boxes/schema.json
+++ b/Porto-Icon-Boxes/schema.json
@@ -5,6 +5,11 @@
       "type": "string",
       "title": "Module Title"
     },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Items": {
       "type": "array",
       "title": "Content Items",

--- a/Porto-Icons/Template.cshtml
+++ b/Porto-Icons/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @foreach (var item in Model.Items)
 {
     <em class="@item.Icon"></em>

--- a/Porto-Icons/builder.json
+++ b/Porto-Icons/builder.json
@@ -7,6 +7,19 @@
       "advanced": false
     },
     {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Items",
       "fieldtype": "array",
       "subfields": [

--- a/Porto-Icons/options.json
+++ b/Porto-Icons/options.json
@@ -1,8 +1,13 @@
 {
     "fields": {
-      "ModuleTitle": {
-        "type": "text"
-      },
+     "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
       "Items": {
         "type": "array",
         "items": {

--- a/Porto-Icons/schema.json
+++ b/Porto-Icons/schema.json
@@ -2,9 +2,14 @@
     "type": "object",
     "properties": {
       "ModuleTitle": {
-        "type": "string",
-        "title": "Module Title"
-      },
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
       "Items": {
         "type": "array",
         "items": {

--- a/Porto-Image-Frames/Template.cshtml
+++ b/Porto-Image-Frames/Template.cshtml
@@ -5,6 +5,10 @@
   }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="row event">
   @if (Model.Items != null)
   {

--- a/Porto-Image-Frames/builder.json
+++ b/Porto-Image-Frames/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Items",
       "title": "Items",
       "fieldtype": "array",

--- a/Porto-Image-Frames/options.json
+++ b/Porto-Image-Frames/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Items": {
       "type": "array",
       "items": {

--- a/Porto-Image-Frames/schema.json
+++ b/Porto-Image-Frames/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Items": {
       "type": "array",
       "title": "Items",

--- a/Porto-Image-Frames/view.json
+++ b/Porto-Image-Frames/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Items": "#pos_1_1"
     }
   }

--- a/Porto-Image-Gallery/Template.cshtml
+++ b/Porto-Image-Gallery/Template.cshtml
@@ -5,6 +5,10 @@
     }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Settings.Style == "Masonry 2")
 {
     <div class="lightbox restaurant" data-plugin-options="{'delegate': 'a', 'type': 'image', 'gallery': {'enabled': true}}">

--- a/Porto-Image-Gallery/builder.json
+++ b/Porto-Image-Gallery/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Groups",
       "title": "Groups",
       "fieldtype": "array",

--- a/Porto-Image-Gallery/options.json
+++ b/Porto-Image-Gallery/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Groups": {
       "type": "array",
       "items": {

--- a/Porto-Image-Gallery/schema.json
+++ b/Porto-Image-Gallery/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Groups": {
       "type": "array",
       "title": "Groups",

--- a/Porto-Image-Gallery/view.json
+++ b/Porto-Image-Gallery/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Groups": "#pos_1_1",
       "Items": "#pos_1_1"
     }

--- a/Porto-Image/Template.cshtml
+++ b/Porto-Image/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="container">
     <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
         @if (Model.Image != null)

--- a/Porto-Image/builder.json
+++ b/Porto-Image/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Image",
       "title": "Image (required)",
       "fieldtype": "image",

--- a/Porto-Image/options.json
+++ b/Porto-Image/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Image": {
       "type": "image"
     },

--- a/Porto-Image/schema.json
+++ b/Porto-Image/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Image": {
       "type": "string",
       "title": "Image (required)",

--- a/Porto-Image/view.json
+++ b/Porto-Image/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Image": "#pos_1_1",
       "Classes": "#pos_1_1",
       "AltText": "#pos_1_1"

--- a/Porto-Labels-Headings/Template.cshtml
+++ b/Porto-Labels-Headings/Template.cshtml
@@ -1,1 +1,5 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <@Model.Settings.SubHeadingSize  class="">@Model.Heading <span class="@Model.Settings.SubHeadingColor"> @Model.SubHeading</span> </@Model.Settings.SubHeadingSize>

--- a/Porto-Labels-Headings/builder.json
+++ b/Porto-Labels-Headings/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Heading",
       "title": "Heading Text (required)",
       "fieldtype": "text",

--- a/Porto-Labels-Headings/options.json
+++ b/Porto-Labels-Headings/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Heading": {
       "type": "text"
     },

--- a/Porto-Labels-Headings/schema.json
+++ b/Porto-Labels-Headings/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Heading": {
       "position": "2col2",
       "type": "string",

--- a/Porto-Labels/Template.cshtml
+++ b/Porto-Labels/Template.cshtml
@@ -1,1 +1,5 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <span class="@Model.Settings.LabelSize @Model.Settings.LabelColor">@Model.Label</span>

--- a/Porto-Labels/builder.json
+++ b/Porto-Labels/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Label",
       "title": "Label Text (required)",
       "fieldtype": "wysihtml",

--- a/Porto-Labels/options.json
+++ b/Porto-Labels/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Label": {
       "type": "wysihtml"
     }    

--- a/Porto-Labels/schema.json
+++ b/Porto-Labels/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Label": {
       "type": "string",
       "title": "Label Text (required)",

--- a/Porto-Lightboxes-Dialog/Template.cshtml
+++ b/Porto-Lightboxes-Dialog/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Settings.Style == "Animation")
 {
     <a

--- a/Porto-Lightboxes-Dialog/builder.json
+++ b/Porto-Lightboxes-Dialog/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "ButtonText",
       "title": "Button Text",
       "fieldtype": "text",

--- a/Porto-Lightboxes-Dialog/options.json
+++ b/Porto-Lightboxes-Dialog/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "ButtonText": {
       "type": "text"
     },

--- a/Porto-Lightboxes-Dialog/schema.json
+++ b/Porto-Lightboxes-Dialog/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "ButtonText": {
       "type": "string",
       "title": "Button Text"

--- a/Porto-Lightboxes-Dialog/view.json
+++ b/Porto-Lightboxes-Dialog/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "ButtonText": "#pos_1_1",
       "DialogTitle": "#pos_1_1",
       "DialogText": "#pos_1_1",

--- a/Porto-Lightboxes/Template.cshtml
+++ b/Porto-Lightboxes/Template.cshtml
@@ -5,7 +5,10 @@
     }
 }
 
-
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Settings.SHOW == "Single-Image")
 {
     <div class="row">

--- a/Porto-Lightboxes/builder.json
+++ b/Porto-Lightboxes/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "SingleImage",
       "title": "Single Image",
       "fieldtype": "image",

--- a/Porto-Lightboxes/options.json
+++ b/Porto-Lightboxes/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "SingleImage": {
       "type": "image"
     },

--- a/Porto-Lightboxes/schema.json
+++ b/Porto-Lightboxes/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "SingleImage": {
       "type": "string",
       "title": "Single Image"

--- a/Porto-Lightboxes/view.json
+++ b/Porto-Lightboxes/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "SingleImage": "#pos_1_1",
       "ImageGallery": "#pos_1_1"
     }

--- a/Porto-Maps-Template/Template.cshtml
+++ b/Porto-Maps-Template/Template.cshtml
@@ -12,7 +12,10 @@
           return string.Join("?", markers);
     }
 }
-
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Settings.ShowBorders)
 {
      <div class="google-map-borders">

--- a/Porto-Maps-Template/builder.json
+++ b/Porto-Maps-Template/builder.json
@@ -1,6 +1,25 @@
 {
     "formfields": [
       {
+        "fieldname": "ModuleTitle",
+        "title": "Module Title",
+        "fieldtype": "text",
+        "advanced": false
+      },
+      {
+        "fieldname": "ModuleAnchor",
+        "title": "Module Anchor",
+        "fieldtype": "text",
+        "advanced": true,
+        "required": false,
+        "hidden": false,
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "multilanguage": false,
+        "index": false,
+        "position": "1col1",
+        "dependencies": []
+      },
+      {
         "fieldname": "Latitud",
         "title": "Latitud",
         "fieldtype": "text",

--- a/Porto-Maps-Template/options.json
+++ b/Porto-Maps-Template/options.json
@@ -1,5 +1,13 @@
 {
     "fields": {
+      "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
       "Latitud": {
         "type": "text"
       },

--- a/Porto-Maps-Template/schema.json
+++ b/Porto-Maps-Template/schema.json
@@ -1,6 +1,15 @@
 {
     "type": "object",
     "properties": {
+      "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
       "Latitud": {
         "type": "string",
         "title": "Latitud (required)",

--- a/Porto-Medias/Template.cshtml
+++ b/Porto-Medias/Template.cshtml
@@ -3,6 +3,10 @@
     var url = Model.Url;
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (style == "YouTube")
 {
     if (!string.IsNullOrEmpty(url))

--- a/Porto-Medias/builder.json
+++ b/Porto-Medias/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Url",
       "title": "Url Address (embed type - required)",
       "fieldtype": "text",

--- a/Porto-Medias/options.json
+++ b/Porto-Medias/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Url": {
       "type": "text",
       "helper": "Find documentation of embed videos at: <a href=\"https://support.google.com/youtube/answer/171780?hl=en\" target=\"_blank\">Click Here!</a>"

--- a/Porto-Medias/schema.json
+++ b/Porto-Medias/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Url": {
       "type": "string",
       "title": "Url Address (embed type - required)"

--- a/Porto-Medias/view.json
+++ b/Porto-Medias/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Url": "#pos_1_1"
     }
   }

--- a/Porto-Modals-Forms/Template.cshtml
+++ b/Porto-Modals-Forms/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <button class="btn @Model.Settings.ButtonColor" data-toggle="modal" data-target="#formModal">
     @Model.ButtonTitle
 </button>

--- a/Porto-Modals-Forms/builder.json
+++ b/Porto-Modals-Forms/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "ButtonTitle",
       "title": "ButtonTitle",
       "fieldtype": "text",

--- a/Porto-Modals-Forms/options.json
+++ b/Porto-Modals-Forms/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "ButtonTitle": {
       "type": "text"
     },

--- a/Porto-Modals-Forms/schema.json
+++ b/Porto-Modals-Forms/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "ButtonTitle": {
       "type": "string",
       "title": "ButtonTitle"

--- a/Porto-Modals-Forms/view.json
+++ b/Porto-Modals-Forms/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "ButtonTitle": "#pos_1_1",
       "ModalTitle": "#pos_1_1",
       "Items": "#pos_1_1"

--- a/Porto-Modals/Template.cshtml
+++ b/Porto-Modals/Template.cshtml
@@ -1,7 +1,10 @@
 @{
     var styleModal = Model.Settings.StyleModal;
 }
-
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <button class="btn @Model.Settings.ButtonColor @((styleModal == "defaultModal") ? "btn-lg" : "")" data-toggle="modal" data-target="#@styleModal">
     @Model.ButtonText
 </button>

--- a/Porto-Modals/builder.json
+++ b/Porto-Modals/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "ModalTitle",
       "title": "Modal Title (required)",
       "fieldtype": "text",

--- a/Porto-Modals/options.json
+++ b/Porto-Modals/options.json
@@ -1,4 +1,13 @@
 {
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "ModalTitle": {
       "type": "text"
     },
@@ -11,6 +20,7 @@
         "fields": {
           "Item": {
             "type": "wysihtml"
+          }
         }
       }
     }

--- a/Porto-Modals/schema.json
+++ b/Porto-Modals/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "ModalTitle": {
       "type": "string",
       "title": "Modal Title (required)",

--- a/Porto-Modals/view.json
+++ b/Porto-Modals/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "ModalTitle": "#pos_1_1",
       "ButtonText": "#pos_1_1",
       "Items": "#pos_1_1"

--- a/Porto-Ordered-List/Template.cshtml
+++ b/Porto-Ordered-List/Template.cshtml
@@ -2,6 +2,10 @@
     var className = string.IsNullOrEmpty(Model.Settings.ListStyle) ? "": string.Format("list list-ordened {0}", Model.Settings.ListStyle);   
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <ol class="@className">
     @foreach (var item in Model.Items)
     {

--- a/Porto-Ordered-List/builder.json
+++ b/Porto-Ordered-List/builder.json
@@ -1,11 +1,24 @@
 {
     "formfields": [
-    {
-      "fieldname": "ModuleTitle",
-      "title": "Module Title",
-      "fieldtype": "text",
-      "advanced": false
-    },
+      {
+        "fieldname": "ModuleTitle",
+        "title": "Module Title",
+        "fieldtype": "text",
+        "advanced": false
+      },
+      {
+        "fieldname": "ModuleAnchor",
+        "title": "Module Anchor",
+        "fieldtype": "text",
+        "advanced": true,
+        "required": false,
+        "hidden": false,
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "multilanguage": false,
+        "index": false,
+        "position": "1col1",
+        "dependencies": []
+      },
     {
       "fieldname": "Items",
       "fieldtype": "array",

--- a/Porto-Ordered-List/options.json
+++ b/Porto-Ordered-List/options.json
@@ -3,6 +3,11 @@
       "ModuleTitle": {
         "type": "text"
       },
+      "ModuleAnchor": {
+        "type": "text",
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "showMessages": false
+      },
       "Items": {
         "type": "array",
         "items": {

--- a/Porto-Ordered-List/schema.json
+++ b/Porto-Ordered-List/schema.json
@@ -1,10 +1,15 @@
 {
     "type": "object",
     "properties": {
-      "ModuleTitle": {
-        "type": "string",
-        "title": "Module Title"
-      },
+     "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
       "Items": {
         "type": "array",
         "items": {

--- a/Porto-Pagination/Template.cshtml
+++ b/Porto-Pagination/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <ul class="@Model.Settings.ButtonSize">
     <li class="page-item">
         <a class="page-link" href="#">

--- a/Porto-Pagination/builder.json
+++ b/Porto-Pagination/builder.json
@@ -7,6 +7,19 @@
       "advanced": false
     },
     {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Items",
       "fieldtype": "array",
       "subfields": [

--- a/Porto-Pagination/options.json
+++ b/Porto-Pagination/options.json
@@ -3,6 +3,11 @@
     "ModuleTitle": {
       "type": "text"
     },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Items": {
       "type": "array",
       "items": {

--- a/Porto-Pagination/schema.json
+++ b/Porto-Pagination/schema.json
@@ -5,6 +5,11 @@
       "type": "string",
       "title": "Module Title"
     },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Items": {
       "type": "array",
       "items": {

--- a/Porto-Pagination/view.json
+++ b/Porto-Pagination/view.json
@@ -4,6 +4,7 @@
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
       "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Items": "#pos_1_1"
     }
   }

--- a/Porto-Paragraphs-Side-Image/Template.cshtml
+++ b/Porto-Paragraphs-Side-Image/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="container">
     <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
         @if ((Model.Settings.ImagePosition ?? "right").ToLower() == "left")

--- a/Porto-Paragraphs-Side-Image/builder.json
+++ b/Porto-Paragraphs-Side-Image/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Paragraph",
       "title": "Paragraph Text (required)",
       "fieldtype": "ckeditor",

--- a/Porto-Paragraphs-Side-Image/options.json
+++ b/Porto-Paragraphs-Side-Image/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Paragraph": {
       "type": "ckeditor",
       "configset": "basic"

--- a/Porto-Paragraphs-Side-Image/schema.json
+++ b/Porto-Paragraphs-Side-Image/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Paragraph": {
       "type": "string",
       "title": "Paragraph Text (required)",

--- a/Porto-Paragraphs-Side-Image/view.json
+++ b/Porto-Paragraphs-Side-Image/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Paragraph": "#pos_1_1",
       "Image": "#pos_1_1",
       "Classes": "#pos_1_1",

--- a/Porto-Paragraphs/Template.cshtml
+++ b/Porto-Paragraphs/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="container">
     <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
         @if (Model.Paragraph != null)

--- a/Porto-Paragraphs/builder.json
+++ b/Porto-Paragraphs/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Paragraph",
       "title": "Paragraph Text (required)",
       "fieldtype": "ckeditor",

--- a/Porto-Paragraphs/options.json
+++ b/Porto-Paragraphs/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Paragraph": {
       "type": "ckeditor",
       "configset": "standard"

--- a/Porto-Paragraphs/schema.json
+++ b/Porto-Paragraphs/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Paragraph": {
       "type": "string",
       "title": "Paragraph Text (required)",

--- a/Porto-Paragraphs/view.json
+++ b/Porto-Paragraphs/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Paragraph": "#pos_1_1"
     }
   }

--- a/Porto-Popover/Template.cshtml
+++ b/Porto-Popover/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <a 
     data-plugin-options="{'placement': 'right'}" 
     tabindex="0" 

--- a/Porto-Popover/builder.json
+++ b/Porto-Popover/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Button",
       "title": "Button Text (required)",
       "fieldtype": "text",

--- a/Porto-Popover/options.json
+++ b/Porto-Popover/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Button": {
       "type": "text"
     },

--- a/Porto-Popover/schema.json
+++ b/Porto-Popover/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Button": {
       "type": "string",
       "title": "Button Text (optional)",

--- a/Porto-Posts/Template.cshtml
+++ b/Porto-Posts/Template.cshtml
@@ -5,6 +5,10 @@
   }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Style == "Posts") {
     <div
         class="owl-carousel show-nav-title top-border"

--- a/Porto-Posts/builder.json
+++ b/Porto-Posts/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Style",
       "title": "Style",
       "fieldtype": "select",

--- a/Porto-Posts/options.json
+++ b/Porto-Posts/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Style": {
       "type": "select",
       "sort": false,

--- a/Porto-Posts/schema.json
+++ b/Porto-Posts/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Style": {
       "type": "string",
       "title": "Style",

--- a/Porto-Posts/view.json
+++ b/Porto-Posts/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Style": "#pos_1_1",
       "Posts": "#pos_1_1",
       "ChurchsStyle": "#pos_1_1",

--- a/Porto-Pricing-Tables/Template.cshtml
+++ b/Porto-Pricing-Tables/Template.cshtml
@@ -3,6 +3,10 @@
     var pricingTableSize = Model.Settings.PricingTableSize;
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Settings.PricingTableStyle == "Parallax")
 {
     <section class="parallax section section-text-light section-parallax mt-none mb-none"

--- a/Porto-Pricing-Tables/builder.json
+++ b/Porto-Pricing-Tables/builder.json
@@ -7,6 +7,19 @@
       "advanced": false
     },
     {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "ParallaxImage",
       "title": "Parallax Image",
       "fieldtype": "image",

--- a/Porto-Pricing-Tables/options.json
+++ b/Porto-Pricing-Tables/options.json
@@ -3,6 +3,11 @@
     "ModuleTitle": {
       "type": "text"
     },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "ParallaxImage": {
       "type": "image"
     },

--- a/Porto-Pricing-Tables/schema.json
+++ b/Porto-Pricing-Tables/schema.json
@@ -5,6 +5,11 @@
       "type": "string",
       "title": "Module Title"
     },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "ParallaxImage": {
       "type": "string",
       "title": "Parallax Image"

--- a/Porto-Progress-Bar-Circular/Template.cshtml
+++ b/Porto-Progress-Bar-Circular/Template.cshtml
@@ -2,6 +2,10 @@
     var completedAmmount = Model.CompletedAmmount ?? 0;
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="circular-bar">
   <div class="circular-bar-chart" data-percent="@completedAmmount" data-plugin-options="@string.Format("{6}'size': '{0}' ,'lineWidth': '{1}' , 'barColor' : '{2}' ,'trackColor': '#{3}' , {4} 'lineCap' : '{5}'{7}", Model.Settings.Size,Model.Settings.lineWidth, Model.Settings.barColor, Model.Settings.trackColor, Model.Settings.scaleColor !=null ? string.Format("'scaleColor': '#{0}' ,", Model.Settings.scaleColor) : string.Empty, Model.Settings.lineCap, "{", "}")">
     <strong>@Model.InnerContent</strong>

--- a/Porto-Progress-Bar-Circular/builder.json
+++ b/Porto-Progress-Bar-Circular/builder.json
@@ -1,6 +1,25 @@
 {
     "formfields": [
       {
+        "fieldname": "ModuleTitle",
+        "title": "Module Title",
+        "fieldtype": "text",
+        "advanced": false
+      },
+      {
+        "fieldname": "ModuleAnchor",
+        "title": "Module Anchor",
+        "fieldtype": "text",
+        "advanced": true,
+        "required": false,
+        "hidden": false,
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "multilanguage": false,
+        "index": false,
+        "position": "1col1",
+        "dependencies": []
+      },
+      {
         "fieldname": "InnerContent",
         "title": "Content",
         "fieldtype": "wysihtml",

--- a/Porto-Progress-Bar-Circular/options.json
+++ b/Porto-Progress-Bar-Circular/options.json
@@ -1,10 +1,18 @@
 {
-    "fields": {
-      "InnerContent": {
-        "type": "wysihtml"
-      },
-      "CompletedAmmount": {
-        "type": "text"
-      }
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
+    "InnerContent": {
+      "type": "wysihtml"
+    },
+    "CompletedAmmount": {
+      "type": "text"
     }
+  }
 }

--- a/Porto-Progress-Bar-Circular/schema.json
+++ b/Porto-Progress-Bar-Circular/schema.json
@@ -1,6 +1,15 @@
 {
     "type": "object",
     "properties": {
+      "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
       "InnerContent": {
         "type": "string",
         "title": "Title"

--- a/Porto-Progress-Bar/Template.cshtml
+++ b/Porto-Progress-Bar/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div
     class="progress @((Model.Settings.ProgressBarSize != null) ? Model.Settings.ProgressBarSize : string.Empty) @((Model.Settings.ProgressBorderRadius != null) ? Model.Settings.ProgressBorderRadius : string.Empty)">
     <div class="progress-bar

--- a/Porto-Progress-Bar/builder.json
+++ b/Porto-Progress-Bar/builder.json
@@ -1,6 +1,25 @@
 {
     "formfields": [
       {
+        "fieldname": "ModuleTitle",
+        "title": "Module Title",
+        "fieldtype": "text",
+        "advanced": false
+      },
+      {
+        "fieldname": "ModuleAnchor",
+        "title": "Module Anchor",
+        "fieldtype": "text",
+        "advanced": true,
+        "required": false,
+        "hidden": false,
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "multilanguage": false,
+        "index": false,
+        "position": "1col1",
+        "dependencies": []
+      },
+      {
         "fieldname": "CompletedAmmount",
         "title": "Completed Ammount (required)",
         "fieldtype": "text",

--- a/Porto-Progress-Bar/options.json
+++ b/Porto-Progress-Bar/options.json
@@ -1,5 +1,15 @@
 {
-    "CompletedAmmount": {
-        "type": "text"
-    }    
+    "fields": {
+        "ModuleTitle": {
+            "type": "text"
+        },
+        "ModuleAnchor": {
+            "type": "text",
+            "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+            "showMessages": false
+        },
+        "CompletedAmmount": {
+            "type": "text"
+        }
+    }
 }

--- a/Porto-Progress-Bar/schema.json
+++ b/Porto-Progress-Bar/schema.json
@@ -1,6 +1,15 @@
 {
     "type": "object",
     "properties": {
+      "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
       "CompletedAmmount": {
         "type": "number",
         "title": "Completed Ammount (required)",

--- a/Porto-Section-Parallax/Template.cshtml
+++ b/Porto-Section-Parallax/Template.cshtml
@@ -5,6 +5,10 @@
   }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.StyleType == "HalfSection")
 {
     <div class="container-fluid">

--- a/Porto-Section-Parallax/builder.json
+++ b/Porto-Section-Parallax/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Heading",
       "title": "Heading Text (required)",
       "fieldtype": "wysihtml",

--- a/Porto-Section-Parallax/options.json
+++ b/Porto-Section-Parallax/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Heading": {
       "type": "wysihtml"
     },

--- a/Porto-Section-Parallax/schema.json
+++ b/Porto-Section-Parallax/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Heading": {
       "type": "string",
       "title": "Heading Text (required)"

--- a/Porto-Section-Parallax/view.json
+++ b/Porto-Section-Parallax/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Heading": "#pos_1_1",
       "SubHeading": "#pos_1_1",
       "TextLight": "#pos_1_1",

--- a/Porto-Shapes-Dividers/Template.cshtml
+++ b/Porto-Shapes-Dividers/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Settings.Style == "Style1")
 {
 	<section class="section section-height-5 section-with-shape-divider border-0 lazyload" data-bg-src="@Model.Image">

--- a/Porto-Shapes-Dividers/builder.json
+++ b/Porto-Shapes-Dividers/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Image",
       "title": "Image (optional)",
       "fieldtype": "image",

--- a/Porto-Shapes-Dividers/options.json
+++ b/Porto-Shapes-Dividers/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Image": {
       "type": "image"
     }

--- a/Porto-Shapes-Dividers/schema.json
+++ b/Porto-Shapes-Dividers/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Image": {
       "type": "string",
       "title": "Image (optional)"

--- a/Porto-Shapes-Dividers/view.json
+++ b/Porto-Shapes-Dividers/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Styles": "#pos_1_1",
       "Image": "#pos_1_1"
     }

--- a/Porto-Social-Media-Icons/Template.cshtml
+++ b/Porto-Social-Media-Icons/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <ul class="social-icons">
     @if (Model.Items != null)
     {

--- a/Porto-Social-Media-Icons/builder.json
+++ b/Porto-Social-Media-Icons/builder.json
@@ -7,6 +7,19 @@
         "advanced": false
       },
       {
+        "fieldname": "ModuleAnchor",
+        "title": "Module Anchor",
+        "fieldtype": "text",
+        "advanced": true,
+        "required": false,
+        "hidden": false,
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "multilanguage": false,
+        "index": false,
+        "position": "1col1",
+        "dependencies": []
+      },
+      {
         "fieldname": "Items",
         "fieldtype": "array",
         "subfields": [

--- a/Porto-Social-Media-Icons/options.json
+++ b/Porto-Social-Media-Icons/options.json
@@ -1,8 +1,13 @@
 {
     "fields": {
       "ModuleTitle": {
-        "type": "text"
-      },
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
       "Items": {
         "type": "array",
         "items": {

--- a/Porto-Social-Media-Icons/schema.json
+++ b/Porto-Social-Media-Icons/schema.json
@@ -2,9 +2,14 @@
     "type": "object",
     "properties": {
       "ModuleTitle": {
-        "type": "string",
-        "title": "Module Title"
-      },
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
       "Items": {
         "type": "array",
         "items": {

--- a/Porto-Sticky-Elements/Template.cshtml
+++ b/Porto-Sticky-Elements/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <p>@Model.FirstParagraph</p>
 <div class="sticky-container">
   <div class="row">

--- a/Porto-Sticky-Elements/builder.json
+++ b/Porto-Sticky-Elements/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "FirstParagraph",
       "title": "First Paragraph",
       "fieldtype": "ckeditor",

--- a/Porto-Sticky-Elements/options.json
+++ b/Porto-Sticky-Elements/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "FirstParagraph": {
       "type": "ckeditor"
     },

--- a/Porto-Sticky-Elements/schema.json
+++ b/Porto-Sticky-Elements/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "FirstParagraph": {
       "type": "string",
       "title": "First Paragraph"

--- a/Porto-Sticky-Elements/view.json
+++ b/Porto-Sticky-Elements/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "FirstParagraph": "#pos_1_1",
       "Content": "#pos_1_1",
       "Image": "#pos_1_1",

--- a/Porto-Tables/Template.cshtml
+++ b/Porto-Tables/Template.cshtml
@@ -5,6 +5,10 @@
     }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <table class="table
 @(ConvertToBool(Model.Settings.Striped) ? "table-striped" : "")
 @(ConvertToBool(Model.Settings.Bordered) ? "table-bordered" : "")

--- a/Porto-Tables/builder.json
+++ b/Porto-Tables/builder.json
@@ -1,80 +1,92 @@
 {
-    "formfields": [
-      {
-        "fieldname": "ModuleTitle",
-        "title": "Module Title",
-        "fieldtype": "text",
-        "advanced": false
-      },
-      {        
-          "fieldname": "TableHeadTD",
-          "fieldtype": "array",
-          "subfields": [
-            {
-                "fieldname": "TableHeadTDContent",
-                "title": "Table Column Header (required)",
-                "fieldtype": "text",
-                "advanced": true,
-                "required": true,
-                "hidden": false,
-                "multilanguage": false,
-                "index": false,
-                "position": "1col1",
-                "dependencies": []
-            }
-          ],
+  "formfields": [
+    {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "TableHeadTD",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "TableHeadTDContent",
+          "title": "Table Column Header (required)",
+          "fieldtype": "text",
           "advanced": true,
           "required": true,
           "hidden": false,
+          "multilanguage": false,
+          "index": false,
           "position": "1col1",
-          "dependencies": []      
-      },
-      {
-        "fieldname": "TableBodyTR",
-        "fieldtype": "array",
-        "subfields": [
+          "dependencies": []
+        }
+      ],
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "TableBodyTR",
+      "fieldtype": "array",
+      "subfields": [
+        {
+          "fieldname": "RowClass",
+          "title": "Row Class",
+          "fieldtype": "radio",
+          "optionLabels": [
+            "Info",
+            "Error",
+            "Success",
+            "Warning"
+          ],
+          "enum": [
+            "info",
+            "danger",
+            "success",
+            "warning"
+          ],
+          "removeDefaultNone": true,
+          "advanced": false
+        },
+        {
+          "fieldname": "TableBodyTD",
+          "fieldtype": "array",
+          "subfields": [
             {
-              "fieldname": "RowClass",
-              "title": "Row Class",
-              "fieldtype": "radio",
-              "optionLabels": [                
-                "Info",
-                "Error",
-                "Success",
-                "Warning"
-              ],
-              "enum": [                
-                "info",
-                "danger",
-                "success",
-                "warning"
-              ],
-              "removeDefaultNone": true,
-              "advanced": false
-            },
-            {
-              "fieldname": "TableBodyTD",
-              "fieldtype": "array",
-              "subfields": [
-                {
-                  "fieldname": "TableBodyTDContent",
-                  "title": "List Item Text (required)",
-                  "fieldtype": "wysihtml",
-                  "advanced": true,
-                  "required": true,
-                  "hidden": false,
-                  "multilanguage": false,
-                  "index": false,
-                  "position": "1col1",
-                  "dependencies": []
-                }   
-              ],
-              "advanced": false
-          }
-          
-        ],
-        "advanced": false
-       }
-    ],
-    "formtype": "object"
-  }
+              "fieldname": "TableBodyTDContent",
+              "title": "List Item Text (required)",
+              "fieldtype": "wysihtml",
+              "advanced": true,
+              "required": true,
+              "hidden": false,
+              "multilanguage": false,
+              "index": false,
+              "position": "1col1",
+              "dependencies": []
+            }
+          ],
+          "advanced": false
+        }
+      ],
+      "advanced": false
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Tables/options.json
+++ b/Porto-Tables/options.json
@@ -1,40 +1,44 @@
 {
-    "fields": {
-      "ModuleTitle": {
-        "type": "text"
-      },
-      "TableHeadTD": {
-        "type": "array",
-        "items": {
-          "TableHeadTDContent": {
-            "type": "text",
-            "label": "Table Header Text (required)"
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
+    "TableHeadTD": {
+      "type": "array",
+      "items": {
+        "TableHeadTDContent": {
+          "type": "text",
+          "label": "Table Header Text (required)"
+        }
+      }
+    },
+    "TableBodyTR": {
+      "type": "array",
+      "items": {
+        "RowClass": {
+          "type": "radio",
+          "optionLabels": [
+            "Info",
+            "Error",
+            "Success",
+            "Warning"
+          ],
+          "removeDefaultNone": true
+        },
+        "TableBodyTD": {
+          "type": "array",
+          "items": {
+            "TableBodyTDContent": {
+              "type": "wysihtml"
+            }
           }
         }
-      },
-      "TableBodyTR": {
-        "type": "array",
-        "items": {          
-            "RowClass": {
-              "type": "radio",
-              "optionLabels": [                
-                "Info",
-                "Error",
-                "Success",
-                "Warning"
-              ],
-              "removeDefaultNone": true
-            },
-            "TableBodyTD": 
-            {
-              "type": "array",
-              "items": {
-                "TableBodyTDContent": {
-                  "type": "wysihtml"
-                }
-              }
-            }  
-         }
-      }     
+      }
     }
+  }
 }

--- a/Porto-Tables/schema.json
+++ b/Porto-Tables/schema.json
@@ -1,64 +1,69 @@
 {
-    "type": "object",
-    "properties": {
-      "ModuleTitle": {
-        "type": "string",
-        "title": "Module Title"
-      },
-      "TableHeadTD": {
-        "type": "array",
-        "title": "Table Head",
-        "items": {
-          "type": "object",
-          "title": "Add Table Headers",
-          "properties":{
-            "TableHeadTDContent": {             
-                "type": "string",
-                "title": "Table Column Header (required)",
-                "required": true
-            } 
-          }                   
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+      "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
+    "TableHeadTD": {
+      "type": "array",
+      "title": "Table Head",
+      "items": {
+        "type": "object",
+        "title": "Add Table Headers",
+        "properties": {
+          "TableHeadTDContent": {
+            "type": "string",
+            "title": "Table Column Header (required)",
+            "required": true
+          }
         }
-      },
-      "TableBodyTR": {
-        "type": "array",
-        "title": "Table Body",
-        "items": {
-          "type": "object",
-          "title": "Row",
-          "properties": {
-              "RowClass": {
-                "type": "radio",
-                "title": "Row Class",
-                "optionLabels": [
-                  "Info",
-                  "Error",
-                  "Success",
-                  "Warning"
-                ],
-                "enum": [
-                  "info",
-                  "danger",
-                  "success",
-                  "warning"
-                ]
-              },
-              "TableBodyTD":{
-              "type": "array",
-              "title": "Cells",
-               "items": {
-                "type": "object",
-                "properties": {
-                  "TableBodyTDContent": {
-                    "type": "string",
-                    "title": "Cell Content (required)",
-                    "required": true
-                  }
+      }
+    },
+    "TableBodyTR": {
+      "type": "array",
+      "title": "Table Body",
+      "items": {
+        "type": "object",
+        "title": "Row",
+        "properties": {
+          "RowClass": {
+            "type": "radio",
+            "title": "Row Class",
+            "optionLabels": [
+              "Info",
+              "Error",
+              "Success",
+              "Warning"
+            ],
+            "enum": [
+              "info",
+              "danger",
+              "success",
+              "warning"
+            ]
+          },
+          "TableBodyTD": {
+            "type": "array",
+            "title": "Cells",
+            "items": {
+              "type": "object",
+              "properties": {
+                "TableBodyTDContent": {
+                  "type": "string",
+                  "title": "Cell Content (required)",
+                  "required": true
                 }
-               }
+              }
             }
           }
         }
       }
     }
+  }
 }

--- a/Porto-Tabs/Template.cshtml
+++ b/Porto-Tabs/Template.cshtml
@@ -9,11 +9,13 @@
    var activeTabNumber = @Model.ActiveTabNumber;
 }
 
-
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div id="error-message-container">
     <p id="error-message" style="color: red; font-weight: bold; display: none;">Tab @activeTabNumber does not exist. Select another tab number.</p>
 </div>
-
 
 @if (Model.Settings.TabMode == "navigation")
 {

--- a/Porto-Tabs/builder.json
+++ b/Porto-Tabs/builder.json
@@ -7,6 +7,19 @@
       "advanced": false
     },
     {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "ActiveTabDefault",
       "title": "ActiveTab-Default?",
       "fieldtype": "checkbox",

--- a/Porto-Tabs/options.json
+++ b/Porto-Tabs/options.json
@@ -3,6 +3,11 @@
     "ModuleTitle": {
       "type": "text"
     },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "ActiveTabDefault": {
       "type": "checkbox"
     },

--- a/Porto-Tabs/schema.json
+++ b/Porto-Tabs/schema.json
@@ -5,6 +5,11 @@
       "type": "string",
       "title": "Module Title"
     },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "ActiveTabDefault": {
       "type": "boolean",
       "title": "ActiveTab-Default?",

--- a/Porto-Tabs/view.json
+++ b/Porto-Tabs/view.json
@@ -4,6 +4,7 @@
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
       "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "ActiveTabDefault": "#pos_1_1",
       "ActiveTabNumber": "#pos_1_1",
       "Items": "#pos_1_1"

--- a/Porto-Testimonials-Carousel/Template.cshtml
+++ b/Porto-Testimonials-Carousel/Template.cshtml
@@ -5,6 +5,10 @@
   }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (ConvertToBool(Model.Settings.Parallax))
 {
     <section class="parallax section section-text-light section-parallax section-center mt-none mb-none"

--- a/Porto-Testimonials-Carousel/builder.json
+++ b/Porto-Testimonials-Carousel/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "ParallaxImage",
       "title": "ParallaxImage",
       "fieldtype": "image",

--- a/Porto-Testimonials-Carousel/options.json
+++ b/Porto-Testimonials-Carousel/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "ParallaxImage": {
       "type": "image"
     },

--- a/Porto-Testimonials-Carousel/schema.json
+++ b/Porto-Testimonials-Carousel/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "ParallaxImage": {
       "type": "string",
       "title": "ParallaxImage"

--- a/Porto-Testimonials-Carousel/view.json
+++ b/Porto-Testimonials-Carousel/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "ParallaxImage": "#pos_1_1",
       "Items": "#pos_1_1"
     }

--- a/Porto-Testimonials/Template.cshtml
+++ b/Porto-Testimonials/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="@string.Format("testimonial {0} {1}", Model.Settings.Color, Model.Settings.Style)">
     <blockquote>
         <p>@Model.Content</p>

--- a/Porto-Testimonials/builder.json
+++ b/Porto-Testimonials/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Content",
       "title": "Content Text (required)",
       "fieldtype": "textarea",

--- a/Porto-Testimonials/options.json
+++ b/Porto-Testimonials/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Content": {
       "type": "textarea"
     },

--- a/Porto-Testimonials/schema.json
+++ b/Porto-Testimonials/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Content": {
       "type": "string",
       "title": "Content Text (required)",

--- a/Porto-Testimonials/view.json
+++ b/Porto-Testimonials/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Content": "#pos_1_1",
       "Image": "#pos_1_1",
       "Fullname": "#pos_1_1",

--- a/Porto-Toggle/Template.cshtml
+++ b/Porto-Toggle/Template.cshtml
@@ -5,6 +5,10 @@
   }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <div class="toggle @Model.Settings.Color @Model.Settings.Size @Model.Settings.Mode"
      @(ConvertToBool(Model.Settings.OneOnly) ? "data-plugin-options=\"{ 'isAccordion': true }\"" : "")
      data-plugin-toggle="toggle" id="toggle-@Model.Context.ModuleId">

--- a/Porto-Toggle/builder.json
+++ b/Porto-Toggle/builder.json
@@ -7,6 +7,19 @@
       "advanced": false
     },
     {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Items",
       "fieldtype": "array",
       "subfields": [

--- a/Porto-Toggle/options.json
+++ b/Porto-Toggle/options.json
@@ -3,6 +3,11 @@
     "ModuleTitle": {
       "type": "text"
     },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Items": {
       "type": "array",
       "items": {

--- a/Porto-Toggle/schema.json
+++ b/Porto-Toggle/schema.json
@@ -5,6 +5,11 @@
       "type": "string",
       "title": "Module Title"
     },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Items": {
       "type": "array",
       "items": {

--- a/Porto-Tooltip/Template.cshtml
+++ b/Porto-Tooltip/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 <button type="button" class="btn @Model.Settings.ButtonColor mr-lg pull-left" data-plugin-tooltip="tooltip"
     data-toggle="tooltip" data-placement="@Model.Settings.TooltipDirection" title="@Model.TooltipTitle">
     @Model.ButtonText

--- a/Porto-Tooltip/builder.json
+++ b/Porto-Tooltip/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "ButtonText",
       "title": "Button Text (required)",
       "fieldtype": "text",

--- a/Porto-Tooltip/options.json
+++ b/Porto-Tooltip/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "ButtonText": {
       "type": "text"
     },

--- a/Porto-Tooltip/schema.json
+++ b/Porto-Tooltip/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "ButtonText": {
       "type": "string",
       "title": "Button Text (required)",

--- a/Porto-Tooltip/view.json
+++ b/Porto-Tooltip/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "ButtonText": "#pos_1_1",
       "TooltipTitle": "#pos_1_1"
     }

--- a/Porto-TypeWriter/Template.cshtml
+++ b/Porto-TypeWriter/Template.cshtml
@@ -2,6 +2,10 @@
     var typeWriterStyle = Model.Settings.TypeWriterStyle; 
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (typeWriterStyle == "Default")
 {
     <section class="section section-default-scale-9 center">

--- a/Porto-TypeWriter/builder.json
+++ b/Porto-TypeWriter/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Heading",
       "title": "Heading Text (required)",
       "fieldtype": "text",

--- a/Porto-TypeWriter/options.json
+++ b/Porto-TypeWriter/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Heading": {
       "type": "text"
     },

--- a/Porto-TypeWriter/schema.json
+++ b/Porto-TypeWriter/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Heading": {
       "type": "string",
       "title": "Heading Text (required)",

--- a/Porto-TypeWriter/view.json
+++ b/Porto-TypeWriter/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Heading": "#pos_1_1",
       "Text1": "#pos_1_1",
       "Text2": "#pos_1_1",

--- a/Porto-Typography/Template.cshtml
+++ b/Porto-Typography/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Sections != null)
 {
     foreach (var item in Model.Sections)

--- a/Porto-Typography/builder.json
+++ b/Porto-Typography/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Sections",
       "title": "Sections",
       "fieldtype": "array",

--- a/Porto-Typography/options.json
+++ b/Porto-Typography/options.json
@@ -1,6 +1,14 @@
 {
   "fields": {
     "Sections": {
+      "ModuleTitle": {
+        "type": "text"
+      },
+      "ModuleAnchor": {
+        "type": "text",
+        "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+        "showMessages": false
+      },
       "type": "array",
       "items": {
         "fields": {
@@ -10,7 +18,11 @@
           "Class": {
             "type": "select",
             "sort": false,
-            "optionLabels": ["Default", "Drop Caps", "Drop Caps Style-2"],
+            "optionLabels": [
+              "Default",
+              "Drop Caps",
+              "Drop Caps Style-2"
+            ],
             "removeDefaultNone": true
           },
           "AlternativeFont": {
@@ -34,7 +46,14 @@
           "Size": {
             "type": "select",
             "sort": false,
-            "optionLabels": ["h1", "h2", "h3", "h4", "h5", "h6"]
+            "optionLabels": [
+              "h1",
+              "h2",
+              "h3",
+              "h4",
+              "h5",
+              "h6"
+            ]
           },
           "OtherText": {
             "type": "textarea"

--- a/Porto-Typography/schema.json
+++ b/Porto-Typography/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+      "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Sections": {
       "type": "array",
       "title": "Sections",
@@ -14,7 +23,11 @@
           "Class": {
             "type": "string",
             "title": "Class",
-            "enum": ["default", "drop-caps", "drop-caps drop-caps-style-2"],
+            "enum": [
+              "default",
+              "drop-caps",
+              "drop-caps drop-caps-style-2"
+            ],
             "removeDefaultNone": true
           },
           "AlternativeFont": {
@@ -40,7 +53,14 @@
           "Size": {
             "type": "string",
             "title": "Size",
-            "enum": ["h1", "h2", "h3", "h4", "h5", "h6"]
+            "enum": [
+              "h1",
+              "h2",
+              "h3",
+              "h4",
+              "h5",
+              "h6"
+            ]
           },
           "OtherText": {
             "type": "string",

--- a/Porto-Typography/view.json
+++ b/Porto-Typography/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Sections": "#pos_1_1"
     }
   }

--- a/Porto-UnOrdered-List/Template.cshtml
+++ b/Porto-UnOrdered-List/Template.cshtml
@@ -19,6 +19,10 @@
     }
 }
 
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (ConvertToBool(Model.DescriptionLists))
 {
     <dl>

--- a/Porto-UnOrdered-List/builder.json
+++ b/Porto-UnOrdered-List/builder.json
@@ -7,6 +7,19 @@
       "advanced": false
     },
     {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Descriptionlists",
       "title": "Description lists",
       "fieldtype": "checkbox",

--- a/Porto-UnOrdered-List/options.json
+++ b/Porto-UnOrdered-List/options.json
@@ -1,7 +1,12 @@
 {
   "fields": {
-    "ModuleTitle": {
+   "ModuleTitle": {
       "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
     },
     "Descriptionlists": {
       "type": "checkbox"

--- a/Porto-UnOrdered-List/schema.json
+++ b/Porto-UnOrdered-List/schema.json
@@ -5,6 +5,11 @@
       "type": "string",
       "title": "Module Title"
     },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+       "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Descriptionlists": {
       "type": "boolean",
       "title": "Description lists"

--- a/Porto-UnOrdered-List/view.json
+++ b/Porto-UnOrdered-List/view.json
@@ -4,6 +4,7 @@
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
       "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Descriptionlists": "#pos_1_1",
       "Type": "#pos_1_1",
       "Items": "#pos_1_1",

--- a/Porto-Word-Rotator/Template.cshtml
+++ b/Porto-Word-Rotator/Template.cshtml
@@ -1,3 +1,7 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
 @if (Model.Sections != null)
 {
     foreach (var item in Model.Sections)

--- a/Porto-Word-Rotator/builder.json
+++ b/Porto-Word-Rotator/builder.json
@@ -1,6 +1,25 @@
 {
   "formfields": [
     {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
       "fieldname": "Sections",
       "title": "Sections",
       "fieldtype": "array",

--- a/Porto-Word-Rotator/options.json
+++ b/Porto-Word-Rotator/options.json
@@ -1,5 +1,13 @@
 {
   "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "showMessages": false
+    },
     "Sections": {
       "type": "array",
       "items": {
@@ -32,7 +40,14 @@
           "Size": {
             "type": "select",
             "sort": false,
-            "optionLabels": ["h1", "h2", "h3", "h4", "h5", "h6"],
+            "optionLabels": [
+              "h1",
+              "h2",
+              "h3",
+              "h4",
+              "h5",
+              "h6"
+            ],
             "removeDefaultNone": true
           },
           "OtherText": {

--- a/Porto-Word-Rotator/schema.json
+++ b/Porto-Word-Rotator/schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+      "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
     "Sections": {
       "type": "array",
       "title": "Sections",
@@ -40,7 +49,14 @@
           "Size": {
             "type": "string",
             "title": "Size",
-            "enum": ["h1", "h2", "h3", "h4", "h5", "h6"],
+            "enum": [
+              "h1",
+              "h2",
+              "h3",
+              "h4",
+              "h5",
+              "h6"
+            ],
             "removeDefaultNone": true
           },
           "OtherText": {

--- a/Porto-Word-Rotator/view.json
+++ b/Porto-Word-Rotator/view.json
@@ -3,6 +3,8 @@
   "layout": {
     "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
     "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
       "Sections": "#pos_1_1"
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added two new fields to the Open Content schema and templates where they were missing:

- **Module Title**: Allows updating the module's title on save.
- **Module Anchor**: Allows setting a custom anchor ID for the module. If the value is not empty, a separate `<div>` is rendered at the top of the template with the specified `id`.

The **Module Title** update was applied only to templates that did not already include this field.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Verified that the **Module Title** updates the module title correctly upon saving.
- Added a value to the **Module Anchor** field and confirmed that a `<div>` with the corresponding `id` is rendered at the top of the module.
- Tested anchor link navigation from the page URL (e.g., `#my-anchor`) to ensure it scrolls to the correct location.
- Ensured backward compatibility: templates without a ModuleAnchor value continue working normally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.