### PR TITLE
Disable DNN Admin Messages in All Razor Templates

### DIFF
--- a/DNN-Messages/Template.cshtml
+++ b/DNN-Messages/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Header-Banner-NoBS/Template.cshtml
+++ b/Header-Banner-NoBS/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var headerBackgroundColor = Model.Settings.HeaderBackgroundColor;
     var headerTextColor = Model.Settings.HeaderTextColor;
     var headerTagType = Model.Settings.HeaderTextType;

--- a/Modal-Dialog-NoBS/Template.cshtml
+++ b/Modal-Dialog-NoBS/Template.cshtml
@@ -1,5 +1,23 @@
 @using DotNetNuke.Entities.Users
+@using DotNetNuke.Entities.Modules
+
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var headerBackgroundColor = Model.Settings.HeaderBackgroundColor;
     var headerTextColor = Model.Settings.HeaderTextColor;
     var headerTagType = Model.Settings.HeaderTextType;

--- a/Modal-Dialog/Template.cshtml
+++ b/Modal-Dialog/Template.cshtml
@@ -4,9 +4,26 @@
 @using Newtonsoft.Json
 @using System.Net.Http.Headers
 @inherits Satrabel.OpenContent.Components.OpenContentWebPage
+@using DotNetNuke.Entities.Modules
 
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet">
 @{
+  // Update or create the "hideadminborder" setting with the value "True"
+  var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+  if (currentModule != null && currentModule.TabModuleID > 0)
+  {
+    // Check if the "hideadminborder" setting is not set or is not "True"
+    var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+    ? currentModule.TabModuleSettings["hideadminborder"]
+    : null;
+
+    if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+    {
+      // Update or create the "hideadminborder" setting with the value "True"
+      ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+    }
+  }
+
   var headerBackgroundColor = Model.Settings.HeaderBackgroundColor;
   var headerTextColor = Model.Settings.HeaderTextColor;
   var headerTextType = Model.Settings.HeaderTextType;

--- a/Move-Plugin/Template.cshtml
+++ b/Move-Plugin/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var querySelector = Model.querySelector == "custom" ? Model.queryValue : string.Format("{0}{1}",
     Model.querySelector, Model.queryValue);
     var editMode = Model.editMode!=null ? Model.editMode.ToString().ToLower() : "false";

--- a/Porto-Accordion/Template.cshtml
+++ b/Porto-Accordion/Template.cshtml
@@ -1,12 +1,30 @@
 @using System.Collections.Generic
+@using DotNetNuke.Entities.Modules
 
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var itemsWithIndex = new List<dynamic>();
     for (int i = 0; i < Model.Items.Length; i++)
     {
         itemsWithIndex.Add(new { value = Model.Items[i], index = i });
     }
 }
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Alerts/Template.cshtml
+++ b/Porto-Alerts/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Animations/Template.cshtml
+++ b/Porto-Animations/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Arrows/Template.cshtml
+++ b/Porto-Arrows/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+  // Update or create the "hideadminborder" setting with the value "True"
+  var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+  if (currentModule != null && currentModule.TabModuleID > 0)
+  {
+    // Check if the "hideadminborder" setting is not set or is not "True"
+    var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+    ? currentModule.TabModuleSettings["hideadminborder"]
+    : null;
+
+    if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+    {
+      // Update or create the "hideadminborder" setting with the value "True"
+      ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+    }
+  }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Before-After/Template.cshtml
+++ b/Porto-Before-After/Template.cshtml
@@ -1,4 +1,20 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
     var settings = Model.Settings;
 }
 

--- a/Porto-Blockquotes/Template.cshtml
+++ b/Porto-Blockquotes/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Buttons/Template.cshtml
+++ b/Porto-Buttons/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+    
     var rel = Model.Rel != null ? (Model.Rel == "custom" ? (Model.CustomRel ?? string.Empty) : Model.Rel) : string.Empty;
     var target = Model.Target != null ? (Model.Target == "custom" ? (Model.CustomTarget ?? string.Empty) : Model.Target) : string.Empty;
 

--- a/Porto-Call-To-Action/Template.cshtml
+++ b/Porto-Call-To-Action/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var isParallax = Model.Style == "Parallax";
     var isSmall = Model.Style == "Small";
     var isDefault = Model.Style == "Default";

--- a/Porto-Carousel/Template.cshtml
+++ b/Porto-Carousel/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @{
     var style = Model.Settings.Style != null ? Model.Settings.Style.ToString() : string.Empty;
 }

--- a/Porto-Countdowns/Template.cshtml
+++ b/Porto-Countdowns/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+  // Update or create the "hideadminborder" setting with the value "True"
+  var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+  if (currentModule != null && currentModule.TabModuleID > 0)
+  {
+    // Check if the "hideadminborder" setting is not set or is not "True"
+    var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+    ? currentModule.TabModuleSettings["hideadminborder"]
+    : null;
+
+    if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+    {
+      // Update or create the "hideadminborder" setting with the value "True"
+      ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+    }
+  }
+
   var countdownStyle = Model.Settings.CountdownsStyle;
   var dateTime = Model.DateTime;
   var parallaxImage = Model.ParallaxImage;

--- a/Porto-Counters/Template.cshtml
+++ b/Porto-Counters/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+  // Update or create the "hideadminborder" setting with the value "True"
+  var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+  if (currentModule != null && currentModule.TabModuleID > 0)
+  {
+    // Check if the "hideadminborder" setting is not set or is not "True"
+    var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+    ? currentModule.TabModuleSettings["hideadminborder"]
+    : null;
+
+    if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+    {
+      // Update or create the "hideadminborder" setting with the value "True"
+      ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+    }
+  }
+
   var style = Model.Style;
   var withBackground = Model.WithBackground !=null && Model.WithBackground.ToString().ToLower() == "true";
   var withBorders = Model.WithBorders !=null && Model.WithBorders.ToString().ToLower() == "true";

--- a/Porto-Dividers/Template.cshtml
+++ b/Porto-Dividers/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+            ? currentModule.TabModuleSettings["hideadminborder"]
+            : null;
+       
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var dividerType = Model.Settings.DividerType.ToString();
     var fullWidth = Model.Settings.FullWith ?? false;
     var enableAnimations = Model.Settings.EnableAnimations ?? false;

--- a/Porto-ExtensionList/Template.cshtml
+++ b/Porto-ExtensionList/Template.cshtml
@@ -1,3 +1,5 @@
+@using DotNetNuke.Entities.Modules
+
 @functions {
     public string TruncateString(string description, int maxLength)
     {
@@ -28,8 +30,23 @@
     }
 }
 @{
-    var categoriesArray = new List<string>();
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+            ? currentModule.TabModuleSettings["hideadminborder"]
+            : null;
+       
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
 
+    var categoriesArray = new List<string>();
     if (Model.Extensions != null)
     {
         foreach (var item in Model.Extensions)
@@ -71,7 +88,7 @@
             {
                 <li data-option-value=".@category" class="nav-item">
                     <a href="#">
-                    @GetCategoryLabel(category)            
+                        @GetCategoryLabel(category)            
                     </a>
                 </li>
             }

--- a/Porto-Forms/Template.cshtml
+++ b/Porto-Forms/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Headings/Template.cshtml
+++ b/Porto-Headings/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+            ? currentModule.TabModuleSettings["hideadminborder"]
+            : null;
+       
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Icon-Boxes/Template.cshtml
+++ b/Porto-Icon-Boxes/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+            ? currentModule.TabModuleSettings["hideadminborder"]
+            : null;
+       
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
   public bool ConvertToBool(dynamic value)
   {

--- a/Porto-Icons/Template.cshtml
+++ b/Porto-Icons/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Image-Frames/Template.cshtml
+++ b/Porto-Image-Frames/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+  // Update or create the "hideadminborder" setting with the value "True"
+  var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+  if (currentModule != null && currentModule.TabModuleID > 0)
+  {
+    // Check if the "hideadminborder" setting is not set or is not "True"
+    var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+    ? currentModule.TabModuleSettings["hideadminborder"]
+    : null;
+
+    if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+    {
+      // Update or create the "hideadminborder" setting with the value "True"
+      ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+    }
+  }
+}
+
 @functions {
   public bool ConvertToBool(dynamic value)
   {

--- a/Porto-Image-Gallery/Template.cshtml
+++ b/Porto-Image-Gallery/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
     public bool ConvertToBool(dynamic value)
     {

--- a/Porto-Image/Template.cshtml
+++ b/Porto-Image/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Labels-Headings/Template.cshtml
+++ b/Porto-Labels-Headings/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Labels/Template.cshtml
+++ b/Porto-Labels/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Lightboxes-Dialog/Template.cshtml
+++ b/Porto-Lightboxes-Dialog/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Lightboxes/Template.cshtml
+++ b/Porto-Lightboxes/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
     public bool ConvertToBool(dynamic value)
     {

--- a/Porto-Maps-Template/Template.cshtml
+++ b/Porto-Maps-Template/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+     // Update or create the "hideadminborder" setting with the value "True"
+     var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+     if (currentModule != null && currentModule.TabModuleID > 0)
+     {
+          // Check if the "hideadminborder" setting is not set or is not "True"
+          var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+          ? currentModule.TabModuleSettings["hideadminborder"]
+          : null;
+
+          if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+          {
+               // Update or create the "hideadminborder" setting with the value "True"
+               ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+          }
+     }
+}
+
 @functions{
     public string FormatMarkers(dynamic value)
     {

--- a/Porto-Medias/Template.cshtml
+++ b/Porto-Medias/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var style = Model.Settings.Style;
     var url = Model.Url;
 }

--- a/Porto-Modals-Forms/Template.cshtml
+++ b/Porto-Modals-Forms/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Modals/Template.cshtml
+++ b/Porto-Modals/Template.cshtml
@@ -1,6 +1,24 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var styleModal = Model.Settings.StyleModal;
 }
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Ordered-List/Template.cshtml
+++ b/Porto-Ordered-List/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var className = string.IsNullOrEmpty(Model.Settings.ListStyle) ? "": string.Format("list list-ordened {0}", Model.Settings.ListStyle);   
 }
 

--- a/Porto-Pagination/Template.cshtml
+++ b/Porto-Pagination/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Paragraphs-Side-Image/Template.cshtml
+++ b/Porto-Paragraphs-Side-Image/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Paragraphs/Template.cshtml
+++ b/Porto-Paragraphs/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Popover/Template.cshtml
+++ b/Porto-Popover/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Posts/Template.cshtml
+++ b/Porto-Posts/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
   public bool ConvertToBool(dynamic value)
   {

--- a/Porto-Pricing-Tables/Template.cshtml
+++ b/Porto-Pricing-Tables/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var pricingTableStyle = Model.Settings.PricingTableStyle;
     var pricingTableSize = Model.Settings.PricingTableSize;
 }

--- a/Porto-Progress-Bar-Circular/Template.cshtml
+++ b/Porto-Progress-Bar-Circular/Template.cshtml
@@ -1,4 +1,21 @@
+@using DotNetNuke.Entities.Modules
 @{
+  // Update or create the "hideadminborder" setting with the value "True"
+  var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+  if (currentModule != null && currentModule.TabModuleID > 0)
+  {
+    // Check if the "hideadminborder" setting is not set or is not "True"
+    var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+    ? currentModule.TabModuleSettings["hideadminborder"]
+    : null;
+
+    if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+    {
+      // Update or create the "hideadminborder" setting with the value "True"
+      ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+    }
+  }
+
     var completedAmmount = Model.CompletedAmmount ?? 0;
 }
 

--- a/Porto-Progress-Bar/Template.cshtml
+++ b/Porto-Progress-Bar/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+            ? currentModule.TabModuleSettings["hideadminborder"]
+            : null;
+       
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Section-Parallax/Template.cshtml
+++ b/Porto-Section-Parallax/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+            ? currentModule.TabModuleSettings["hideadminborder"]
+            : null;
+       
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
   public bool ConvertToBool(dynamic value)
   {

--- a/Porto-Shapes-Dividers/Template.cshtml
+++ b/Porto-Shapes-Dividers/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+	// Update or create the "hideadminborder" setting with the value "True"
+	var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+	if (currentModule != null && currentModule.TabModuleID > 0)
+	{
+		// Check if the "hideadminborder" setting is not set or is not "True"
+		var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+		? currentModule.TabModuleSettings["hideadminborder"]
+		: null;
+
+		if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+		{
+			// Update or create the "hideadminborder" setting with the value "True"
+			ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+		}
+	}
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Social-Media-Icons/Template.cshtml
+++ b/Porto-Social-Media-Icons/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Sticky-Elements/Template.cshtml
+++ b/Porto-Sticky-Elements/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+  // Update or create the "hideadminborder" setting with the value "True"
+  var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+  if (currentModule != null && currentModule.TabModuleID > 0)
+  {
+    // Check if the "hideadminborder" setting is not set or is not "True"
+    var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+    ? currentModule.TabModuleSettings["hideadminborder"]
+    : null;
+
+    if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+    {
+      // Update or create the "hideadminborder" setting with the value "True"
+      ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+    }
+  }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Tables/Template.cshtml
+++ b/Porto-Tables/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
     public bool ConvertToBool(dynamic value)
     {

--- a/Porto-Tabs/Template.cshtml
+++ b/Porto-Tabs/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+            ? currentModule.TabModuleSettings["hideadminborder"]
+            : null;
+       
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
     public bool ConvertToBool(dynamic value)
     {

--- a/Porto-Testimonials-Carousel/Template.cshtml
+++ b/Porto-Testimonials-Carousel/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
   public bool ConvertToBool(dynamic value)
   {

--- a/Porto-Testimonials/Template.cshtml
+++ b/Porto-Testimonials/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-Toggle/Template.cshtml
+++ b/Porto-Toggle/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
   public bool ConvertToBool(dynamic value)
   {

--- a/Porto-Tooltip/Template.cshtml
+++ b/Porto-Tooltip/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-TypeWriter/Template.cshtml
+++ b/Porto-TypeWriter/Template.cshtml
@@ -1,4 +1,21 @@
-@{ 
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+
     var typeWriterStyle = Model.Settings.TypeWriterStyle; 
 }
 

--- a/Porto-Typography/Template.cshtml
+++ b/Porto-Typography/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>

--- a/Porto-UnOrdered-List/Template.cshtml
+++ b/Porto-UnOrdered-List/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @functions {
   public bool ConvertToBool(dynamic value)
   {

--- a/Porto-Word-Rotator/Template.cshtml
+++ b/Porto-Word-Rotator/Template.cshtml
@@ -1,3 +1,22 @@
+@using DotNetNuke.Entities.Modules
+@{
+    // Update or create the "hideadminborder" setting with the value "True"
+    var currentModule = ModuleController.Instance.GetModule(Dnn.Module.ModuleID, Dnn.Module.TabID, false);
+    if (currentModule != null && currentModule.TabModuleID > 0)
+    {
+        // Check if the "hideadminborder" setting is not set or is not "True"
+        var currentSetting = currentModule.TabModuleSettings.ContainsKey("hideadminborder")
+        ? currentModule.TabModuleSettings["hideadminborder"]
+        : null;
+
+        if (currentSetting == null || !currentSetting.ToString().Equals("True", StringComparison.OrdinalIgnoreCase))
+        {
+            // Update or create the "hideadminborder" setting with the value "True"
+            ModuleController.Instance.UpdateTabModuleSetting(currentModule.TabModuleID, "hideadminborder", "True");
+        }
+    }
+}
+
 @if (!string.IsNullOrEmpty(Model.ModuleAnchor))
 {
     <div id="@Model.ModuleAnchor"></div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #42 

## Description
<!--- Describe your changes in detail -->
This PR updates all Razor templates in the repository to include logic that disables the DNN admin message UI (HideAdminBorder) at runtime. This change ensures that edit borders and other admin overlays are hidden during page rendering, reducing visual clutter and improving the development and preview experience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.