### PR TITLE
Porto-Buttons template link to use URL type

### DIFF
--- a/Porto-Buttons/Template.cshtml
+++ b/Porto-Buttons/Template.cshtml
@@ -11,7 +11,7 @@
 }
 <div class="container">
     <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
-        <div class="col-md-12">
+        <div class="col-12">
             <div style="text-align: @(Model.Settings != null ? Model.Settings.ButtonAlign : "left");">
                 <a href="@(Model.Link ?? "#")" @rel @target class="btn @(Model.Settings != null ? Model.Settings.ButtonColor : "") @(Model.Settings != null ? Model.Settings.ButtonSize : "") @(Model.Settings != null ? Model.Settings.ButtonStyle : "") mr-xs mb-sm" style="text-decoration: none;">
                     @if (!string.IsNullOrEmpty(Model.Icon))

--- a/Porto-Buttons/builder.json
+++ b/Porto-Buttons/builder.json
@@ -41,8 +41,15 @@
     {
       "fieldname": "Link",
       "title": "Link",
-      "fieldtype": "text",
-      "advanced": false
+      "fieldtype": "url",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Can be a local page (autosuggest) or any other text",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
     },
     {
       "fieldname": "Rel",

--- a/Porto-Buttons/options.json
+++ b/Porto-Buttons/options.json
@@ -16,7 +16,8 @@
       "helper": "Find values at: <a href=\"https://fontawesome.com/icons?d=gallery\" target=\"_blank\">FontAwesome</a>"
     },
     "Link": {
-      "type": "text"
+      "type": "url",
+      "helper": "Can be a local page (autosuggest) or any other text"
     },
     "Rel": {
       "type": "select",


### PR DESCRIPTION
Changed URL type from `Text` to `URL`.  