### PR TITLE
Update Porto-Icon-Boxes

### DIFF
--- a/Porto-Icon-Boxes/Template.cshtml
+++ b/Porto-Icon-Boxes/Template.cshtml
@@ -109,7 +109,7 @@ else
     <div class="box-content">
     @if (Model.Settings.ContentContainers == "2")
     {
-        <div class="row">
+        <div class="row title-row @(Model.Settings.DisplayAxis == "horizontally" ? "title-horizontal-style" : "")">
             @if (Model.Settings.IconPosition == "right")
             {
                 <div class="col-md-9">
@@ -127,20 +127,27 @@ else
                 </div>
             }
         </div>
-        <div class="row">
+        <div class="row description-row">
             <div class="col-md-12">
                 <div>@Html.Raw(item.Content)</div>
-                @if (!String.IsNullOrEmpty(item.ButtonText))
-                {
+               
+            </div>
+        </div>
+        if(!String.IsNullOrEmpty(item.ButtonText))
+        {
+        <div class="row button-row">
+            <div class="col-md-12">
+             
                 <a class="btn btn-lg btn-@Model.Settings.Color mr-xs mb-lg" href="@item.ButtonUrl" target="@item.ButtonTarget">
                     <span>@item.ButtonText</span>
                     @if (!String.IsNullOrEmpty(item.ButtonIcon)) { 
                         @Html.Raw(string.Concat("<i class=\"mx-2 ", item.ButtonIcon, "\"></i>"))
                     }
                 </a>        
-                }
+               
             </div>
         </div>
+         }
     }
     else if (Model.Settings.ContentContainers == "1")
     {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adjusts the layout for elements to ensure that the button is positioned at the bottom of the element, maintaining a consistent and centered design.

Changes Made:

- Reorganized Button Placement:

The button is now positioned at the bottom of the container, after the content and dividers.
A d-flex and flex-column structure was applied to ensure proper alignment and positioning.

- Applied Design Classes:

Added d-flex, flex-column, and mt-auto to stack elements vertically and push the button to the bottom.
Used align-items-center to horizontally center all elements within the container.

- Consistent Spacing:

Adjusted margins (mb-lg, mt-lg) to maintain uniform spacing between elements.

- Expected Outcome:

The button is displayed at the bottom of the container, regardless of the content's height.
The layout is visually consistent and centered, as per the design requirements.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on the UpendoDnn site backup and also on a site with the Porto theme using the default CSS.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/43a4df8f-6b3b-42b7-8d12-91a6e929a49a)
![image](https://github.com/user-attachments/assets/82a40662-ff54-4d92-91a7-2f6742604d9c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.