### PR TITLE
Adds a new Porto-Html-Snippet-Columns template

### DIFF
--- a/Porto-Html-Snippet-Columns/Porto-Paragraphs.html
+++ b/Porto-Html-Snippet-Columns/Porto-Paragraphs.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="icon" href="https://avatars.githubusercontent.com/u/6611381?s=200&v=4" type="image/x-icon">
+    <title>Porto-Paragraphs Documentation</title>
+    <style>
+        /* General Styles */
+        body {
+            color: #333333;
+            font-family: "Open Sans", sans-serif;
+            margin: 20px;
+            line-height: 1.6;
+            background-color: #f9f9f9;
+        }
+
+        h1,
+        h2,
+        h3 {
+            color: #6d5a2c;
+            font-family: "Shadows Into Light", cursive;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: 20px;
+        }
+
+        h2 {
+            font-size: 2rem;
+            margin-top: 30px;
+            margin-bottom: 15px;
+        }
+
+        h3 {
+            font-size: 1.5rem;
+            margin-top: 20px;
+            margin-bottom: 1px;
+        }
+
+        p {
+            margin-bottom: 15px;
+        }
+
+        a {
+            color: #6d5a2c;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        .properties-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+            background-color: #fff;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            border-radius: 10px;
+            overflow: hidden;
+        }
+
+        .properties-table th,
+        .properties-table td {
+            border: 1px solid #ddd;
+            padding: 12px;
+            text-align: left;
+        }
+
+        .properties-table th {
+            background-color: #6d5a2c;
+            color: white;
+            font-weight: bold;
+        }
+
+        .properties-table tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+
+        .note {
+            background-color: #fff8e5;
+            padding: 15px;
+            border-radius: 10px;
+            border: 1px solid #f1c232;
+            margin: 20px 0;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .note strong {
+            color: #6d5a2c;
+        }
+
+        .header {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+            background-color: #f9f9f9;
+            color: #6d5a2c;
+            padding: 20px 10px;
+            border-bottom: 1px solid #ddd;
+        }
+
+        .header img {
+            max-width: 120px;
+            height: auto;
+        }
+
+        .header-content {
+            flex: 1;
+            text-align: center;
+        }
+
+        .header-content h1 {
+            font-size: 2rem;
+            margin: 0;
+            font-family: "Shadows Into Light", cursive;
+        }
+
+        .header-divider {
+            height: 2px;
+            width: 100%;
+            background-color: #6d5a2c;
+            border-radius: 1px;
+        }
+
+        .component-image {
+            width: 100%;
+            max-width: 900px;
+            margin: 10px 0;
+            border-radius: 10px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="header">
+            <img src="https://upendo-website.s3-us-west-1.amazonaws.com/Portals/0/Images/Upendo-logo-trans-230x65.png"
+                alt="Logo">
+            <div class="header-content">
+                <h1>Porto-Paragraphs Documentation</h1>
+            </div>
+        </div>
+        <div class="header-divider"></div>
+
+        <h2>
+            <span class="Head">Overview</span>
+        </h2>
+        <p>The <strong>Porto-Paragraphs</strong> component allows you to create customizable paragraphs with adjustable
+            margins, padding, and rich text formatting. This component is highly flexible and integrates seamlessly
+            with <strong>OpenContent</strong>.</p>
+
+        <p>For more details, check out the <a
+            href="https://github.com/UpendoVentures/OpenContentTemplates/tree/master/Porto-Paragraphs">
+            <strong>Porto-Paragraphs repository on GitHub</strong></a>.
+        </p>
+
+        <h2>
+            <span class="Head">Usage Example</span>
+        </h2>
+        <img src="images/usage-example.png" alt="Usage Example" class="component-image">
+
+        <h2>
+            <span class="Head">Properties</span>
+        </h2>
+        <table class="properties-table">
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Data Type</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Paragraph</td>
+                    <td>String</td>
+                    <td>The paragraph text to display. This field is required and supports rich text formatting.</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h2>
+            <span class="Head">Settings Properties</span>
+        </h2>
+
+        <img src="images/template-settings.png" alt="Settings Properties" class="component-image">
+
+        <table class="properties-table">
+            <thead>
+                <tr>
+                    <th>Property</th>
+                    <th>Data Type</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>MarginTop</td>
+                    <td>String</td>
+                    <td>Defines the top margin of the paragraph. Options include <code>mt-0</code>, <code>mt-1</code>,
+                        <code>mt-2</code>, <code>mt-3</code>, <code>mt-4</code>, <code>mt-5</code>, and
+                        <code>mt-auto</code>.</td>
+                </tr>
+                <tr>
+                    <td>MarginBottom</td>
+                    <td>String</td>
+                    <td>Defines the bottom margin of the paragraph. Options include <code>mb-0</code>, <code>mb-1</code>,
+                        <code>mb-2</code>, <code>mb-3</code>, <code>mb-4</code>, <code>mb-5</code>, and
+                        <code>mb-auto</code>.</td>
+                </tr>
+                <tr>
+                    <td>PaddingTop</td>
+                    <td>String</td>
+                    <td>Defines the top padding of the paragraph. Options include <code>pt-0</code>, <code>pt-1</code>,
+                        <code>pt-2</code>, <code>pt-3</code>, <code>pt-4</code>, <code>pt-5</code>, and
+                        <code>pt-auto</code>.</td>
+                </tr>
+                <tr>
+                    <td>PaddingBottom</td>
+                    <td>String</td>
+                    <td>Defines the bottom padding of the paragraph. Options include <code>pb-0</code>, <code>pb-1</code>,
+                        <code>pb-2</code>, <code>pb-3</code>, <code>pb-4</code>, <code>pb-5</code>, and
+                        <code>pb-auto</code>.</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h2>
+            <span class="Head">Views</span>
+        </h2>
+        <p>Below is an example of how the paragraph component is rendered:</p>
+        <img src="images/view-example.png" alt="View Example" class="component-image">
+
+        <h2>
+            <span class="Head">Notes</span>
+        </h2>
+        <div class="note">
+            <strong>Note:</strong> Ensure that the <strong>Paragraph</strong> field is set correctly to display the
+            desired text. Additionally, verify that the <strong>Settings Properties</strong> match your design
+            requirements.
+        </div>
+    </div>
+</body>
+
+</html>

--- a/Porto-Html-Snippet-Columns/Template-data.json
+++ b/Porto-Html-Snippet-Columns/Template-data.json
@@ -1,0 +1,6 @@
+{
+    "MarginTop": "mt-auto" , 
+    "MarginBottom": "mb-auto",
+    "PaddingTop": "pt-auto",
+    "PaddingBottom": "pb-auto"
+}

--- a/Porto-Html-Snippet-Columns/Template.cshtml
+++ b/Porto-Html-Snippet-Columns/Template.cshtml
@@ -1,0 +1,53 @@
+@if (!string.IsNullOrEmpty(Model.ModuleAnchor))
+{
+    <div id="@Model.ModuleAnchor"></div>
+}
+@if (!string.IsNullOrEmpty(Model.JavaScript)){
+    @Html.Raw(Model.JavaScript)
+}
+
+<div class="container">
+    @if (Model.Columns != null)
+    {
+        <div class="row row-cols-1 row-cols-md-3 g-4 @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
+            @foreach (var column in Model.Columns)
+            {
+                <div class="col">
+                    <div class="card h-100 border-0">
+                        @if (!string.IsNullOrWhiteSpace(column.Header))
+                        {
+                            <div class="card-header bg-transparent border-0">
+                                <h4 class="card-title h5">@Html.Raw(column.Header)</h4>
+                            </div>
+                        }
+
+                        <div class="card-body">
+                            @if (!string.IsNullOrWhiteSpace(column.Description))
+                            {
+                                <div class="card-text mb-3">
+                                    @Html.Raw(column.Description)
+                                </div>
+                            }
+
+                            <div class="d-flex justify-content-center w-100">
+                                @Html.Raw(column.HtmlSnippet)
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-warning mt-4" role="alert">
+            No content columns have been added yet.
+        </div>
+    }
+</div>
+
+@*
+<div class="dnnClear">
+    @ObjectInfo.Print(Model)
+</div>
+*@

--- a/Porto-Html-Snippet-Columns/builder.json
+++ b/Porto-Html-Snippet-Columns/builder.json
@@ -1,0 +1,85 @@
+{
+  "formfields": [
+    {
+      "fieldname": "ModuleTitle",
+      "title": "Module Title",
+      "fieldtype": "text",
+      "advanced": false
+    },
+    {
+      "fieldname": "ModuleAnchor",
+      "title": "Module Anchor",
+      "fieldtype": "text",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only).",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "Columns",
+      "title": "Columns",
+      "fieldtype": "accordion",
+      "subfields": [
+        {
+          "fieldname": "Header",
+          "title": "Header (h3)",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": false,
+          "hidden": false,
+          "helper": "If left blank, it's not rendered. ",
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "Description",
+          "title": "Description",
+          "fieldtype": "ckeditor",
+          "ckeditoroptions": {},
+          "advanced": false
+        },
+        {
+          "fieldname": "HtmlSnippet",
+          "title": "HTML Snippet",
+          "fieldtype": "textarea",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "helper": "Copy & paste the intended HTML snippets from the respective source. ",
+          "placeholder": "<!-- Expecting HTML snippets -->  ",
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        }
+      ],
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "helper": "At least one column is required. Columns will automatically wrap within their pane. ",
+      "position": "1col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "JavaScript",
+      "title": "JavaScript Injection",
+      "fieldtype": "textarea",
+      "advanced": true,
+      "required": false,
+      "hidden": false,
+      "helper": "Meant for a script scoped to all Content Columns. ",
+      "placeholder": "<!-- Usually a <script> tag -->",
+      "multilanguage": false,
+      "index": false,
+      "position": "1col1",
+      "dependencies": []
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Html-Snippet-Columns/data.json
+++ b/Porto-Html-Snippet-Columns/data.json
@@ -1,0 +1,3 @@
+{
+    "Paragraph": "<p>This is my default <strong>paragraph</strong> message</p>"
+}

--- a/Porto-Html-Snippet-Columns/options.json
+++ b/Porto-Html-Snippet-Columns/options.json
@@ -1,0 +1,36 @@
+{
+  "fields": {
+    "ModuleTitle": {
+      "type": "text"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page (numbers, letters, hyphens only)."
+    },
+    "Columns": {
+      "type": "accordion",
+      "helper": "At least one column is required. Columns will automatically wrap within their pane. ",
+      "items": {
+        "fields": {
+          "Header": {
+            "type": "text",
+            "helper": "If left blank, it's not rendered. "
+          },
+          "Description": {
+            "type": "ckeditor"
+          },
+          "HtmlSnippet": {
+            "type": "textarea",
+            "placeholder": "<!-- Expecting HTML snippets -->  ",
+            "helper": "Copy & paste the intended HTML snippets from the respective source. "
+          }
+        }
+      }
+    },
+    "JavaScript": {
+      "type": "textarea",
+      "placeholder": "<!-- Usually a <script> tag -->",
+      "helper": "Meant for a script scoped to all Content Columns. "
+    }
+  }
+}

--- a/Porto-Html-Snippet-Columns/schema.json
+++ b/Porto-Html-Snippet-Columns/schema.json
@@ -1,0 +1,40 @@
+{
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor"
+    },
+    "Columns": {
+      "type": "array",
+      "title": "Columns",
+      "required": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "Header": {
+            "type": "string",
+            "title": "Header (h3)"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "HtmlSnippet": {
+            "type": "string",
+            "title": "HTML Snippet",
+            "required": true
+          }
+        }
+      }
+    },
+    "JavaScript": {
+      "type": "string",
+      "title": "JavaScript Injection"
+    }
+  }
+}

--- a/Porto-Html-Snippet-Columns/template-options.json
+++ b/Porto-Html-Snippet-Columns/template-options.json
@@ -1,0 +1,61 @@
+{
+	"fields": {		
+		"MarginTop": {
+			"title": "Margin (top)",
+			"type": "select",
+			"optionLabels": [
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
+			],
+			"removeDefaultNone": true
+		},		
+		"MarginBottom": {
+			"title": "Margin (bottom)",
+			"type": "select",
+			"optionLabels": [
+				"mb-0",
+				"mb-1",
+				"mb-2",
+				"mb-3",
+				"mb-4",
+				"mb-5",
+				"mb-auto"
+			],
+			"removeDefaultNone": true
+		},
+		"PaddingTop": {
+			"title": "Padding (top)",
+			"type": "select",
+			"optionLabels": [
+				"pt-0",
+				"pt-1",
+				"pt-2",
+				"pt-3",
+				"pt-4",
+				"pt-5",
+				"pt-auto"
+			],
+			"removeDefaultNone": true
+		},
+		"PaddingBottom": {
+			"title": "Padding (bottom)",
+			"type": "select",
+			"optionLabels": [
+				"pb-0",
+				"pb-1",
+				"pb-2",
+				"pb-3",
+				"pb-4",
+				"pb-5",
+				"pb-auto"
+			],
+			"removeDefaultNone": true
+		}	
+
+	}
+}

--- a/Porto-Html-Snippet-Columns/template-schema.json
+++ b/Porto-Html-Snippet-Columns/template-schema.json
@@ -1,0 +1,57 @@
+{
+    "type": "object",
+    "properties": {        
+        "MarginTop": {
+            "title": "Margin (top)",
+            "type": "string",
+            "enum": [
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
+            ]
+        },
+        "MarginBottom": {
+            "title": "Margin (bottom)",
+            "type": "string",
+            "enum": [
+				"mb-0",
+				"mb-1",
+				"mb-2",
+				"mb-3",
+				"mb-4",
+				"mb-5",
+				"mb-auto"
+            ]
+        },
+        "PaddingTop": {
+            "title": "Padding (top)",
+            "type": "string",
+            "enum": [
+				"pt-0",
+				"pt-1",
+				"pt-2",
+				"pt-3",
+				"pt-4",
+				"pt-5",
+				"pt-auto"
+            ]
+        },
+        "PaddingBottom": {
+            "title": "Padding (bottom)",
+            "type": "string",
+            "enum": [
+				"pb-0",
+				"pb-1",
+				"pb-2",
+				"pb-3",
+				"pb-4",
+				"pb-5",
+				"pb-auto"
+            ]
+        }
+    }
+}

--- a/Porto-Html-Snippet-Columns/view.json
+++ b/Porto-Html-Snippet-Columns/view.json
@@ -1,0 +1,12 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-12\" id=\"pos_1_1\"></div></div></div>",
+    "bindings": {
+      "ModuleTitle": "#pos_1_1",
+      "ModuleAnchor": "#pos_1_1",
+      "Columns": "#pos_1_1",
+      "JavaScript": "#pos_1_1"
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
NOne.  

## Description
Adds a new template named `Porto-Html-Snippet-Columns` whose purpose is to allow for option header and description values, followed by required HTML snippets.  The use case is for when you want to include a copy/paste HTML snippet integration.  In this case, the primary use case is [Stripe payment link buttons](https://docs.stripe.com/payment-links/buy-button).  

## How Has This Been Tested?
In production.  

## Screenshots (if appropriate):  
N/A  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.  FYI, @alejoroman0605 