### PR TITLE
Fixes #71

### DIFF
--- a/Porto-Paragraphs-Random-Side-Image/Template-data.json
+++ b/Porto-Paragraphs-Random-Side-Image/Template-data.json
@@ -1,0 +1,6 @@
+{
+    "MarginTop": "mt-auto", 
+    "MarginBottom": "mb-auto",
+    "PaddingTop": "pt-auto",
+    "PaddingBottom": "pb-auto"
+}

--- a/Porto-Paragraphs-Random-Side-Image/Template.cshtml
+++ b/Porto-Paragraphs-Random-Side-Image/Template.cshtml
@@ -1,0 +1,69 @@
+@{
+    int imageCount = 0;
+    Exception error = null;
+    dynamic selectedImage = null;
+
+    try
+    {
+        var images = Model.Images as IEnumerable<dynamic>;
+
+        if (images != null && images.GetEnumerator().MoveNext())
+        {
+            imageCount = images.Count();
+            var random = new Random();
+            int index = random.Next(imageCount);
+            selectedImage = images.ElementAt(index);
+        }
+    }
+    catch (Exception ex)
+    {
+        error = ex;
+    }
+}
+<div class="container">
+    <div class="row @Model.Settings.MarginTop @Model.Settings.MarginBottom @Model.Settings.PaddingTop @Model.Settings.PaddingBottom">
+        <div class="col-md-8">
+            @if (Model.Paragraph != null)
+            {
+                @Html.Raw(Model.Paragraph)
+            }
+            else
+            {
+                <!-- No Paragraph Found -->
+            }
+        </div>
+        <div class="col-md-4">
+            @if (selectedImage != null)
+            {
+                <img src="@selectedImage.ImagePath" alt="@selectedImage.AltText" title="@selectedImage.AltText" class="z-1 appear-animation @selectedImage.CssClass" 
+                    data-bs-toggle="tooltip" data-bs-title="@selectedImage.AltText" data-placement="bottom" data-appear-animation="fadeInUp" />
+            }
+            else
+            {
+                <!-- No Images Found -->
+            }
+        </div>
+    </div>
+</div>
+<script>
+  document.addEventListener("DOMContentLoaded", () => enableToooltips());
+
+  function enableToooltips() {
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+    tooltipTriggerList.forEach(function (tooltipTriggerEl) {
+      new bootstrap.Tooltip(tooltipTriggerEl);
+    });
+  };
+</script>
+@*
+@if (error != null){
+<div class="dnnClear">
+    @ObjectInfo.Print(error)
+</div>
+}
+*@
+@*
+<div class="dnnClear">
+    @ObjectInfo.Print(Model)
+</div>
+*@

--- a/Porto-Paragraphs-Random-Side-Image/builder.json
+++ b/Porto-Paragraphs-Random-Side-Image/builder.json
@@ -1,0 +1,74 @@
+{
+  "formfields": [
+    {
+      "fieldname": "Paragraph",
+      "title": "Paragraph Text (required)",
+      "fieldtype": "ckeditor",
+      "ckeditoroptions": {
+        "configset": "basic"
+      },
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "multilanguage": false,
+      "index": false,
+      "position": "2col1",
+      "dependencies": []
+    },
+    {
+      "fieldname": "Images",
+      "title": "Images",
+      "fieldtype": "accordion",
+      "subfields": [
+        {
+          "fieldname": "AltText",
+          "title": "Alt Text",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "placeholder": "Used for SEO",
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "ImagePath",
+          "title": "Image Path",
+          "fieldtype": "image",
+          "imageoptions": {
+            "folder": "Images"
+          },
+          "advanced": true,
+          "required": true,
+          "hidden": false,
+          "multilanguage": false,
+          "position": "1col1",
+          "dependencies": []
+        },
+        {
+          "fieldname": "CssClass",
+          "title": "CSS Class(es)",
+          "fieldtype": "text",
+          "advanced": true,
+          "required": false,
+          "hidden": false,
+          "default": "img-fluid",
+          "placeholder": "img-fluid",
+          "multilanguage": false,
+          "index": false,
+          "position": "1col1",
+          "dependencies": []
+        }
+      ],
+      "advanced": true,
+      "required": true,
+      "hidden": false,
+      "helper": "At least one image is required. ",
+      "position": "2col2",
+      "dependencies": []
+    }
+  ],
+  "formtype": "object"
+}

--- a/Porto-Paragraphs-Random-Side-Image/data.json
+++ b/Porto-Paragraphs-Random-Side-Image/data.json
@@ -1,0 +1,11 @@
+{
+    "Paragraph": "<p>This is my default <strong>paragraph</strong> message</p>\n",
+    "Images": [
+      {
+        "AltText": "My first image",
+        "ImagePath": "https://placehold.co/600x400",
+        "CssClass": "img-fluid rounded"
+      }
+    ],
+    "_id": "67edaa2fc937df03e8d784fc"
+  }

--- a/Porto-Paragraphs-Random-Side-Image/options.json
+++ b/Porto-Paragraphs-Random-Side-Image/options.json
@@ -1,0 +1,31 @@
+{
+  "fields": {
+    "Paragraph": {
+      "type": "ckeditor",
+      "configset": "basic"
+    },
+    "Images": {
+      "type": "accordion",
+      "helper": "At least one image is required. ",
+      "items": {
+        "fields": {
+          "AltText": {
+            "type": "text",
+            "placeholder": "Used for SEO"
+          },
+          "ImagePath": {
+            "type": "image",
+            "uploadfolder": "Images",
+            "typeahead": {
+              "Folder": "Images"
+            }
+          },
+          "CssClass": {
+            "type": "text",
+            "placeholder": "img-fluid"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Paragraphs-Random-Side-Image/schema.json
+++ b/Porto-Paragraphs-Random-Side-Image/schema.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "Paragraph": {
+      "type": "string",
+      "title": "Paragraph Text (required)",
+      "required": true
+    },
+    "Images": {
+      "type": "array",
+      "title": "Images",
+      "required": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "AltText": {
+            "type": "string",
+            "title": "Alt Text",
+            "required": true
+          },
+          "ImagePath": {
+            "type": "string",
+            "title": "Image Path",
+            "required": true
+          },
+          "CssClass": {
+            "type": "string",
+            "title": "CSS Class(es)",
+            "default": "img-fluid"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Porto-Paragraphs-Random-Side-Image/template-options.json
+++ b/Porto-Paragraphs-Random-Side-Image/template-options.json
@@ -1,0 +1,61 @@
+{
+	"fields": {		
+		"MarginTop": {
+			"title": "Margin (top)",
+			"type": "select",
+			"optionLabels": [
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
+			],
+			"removeDefaultNone": true
+		},		
+		"MarginBottom": {
+			"title": "Margin (bottom)",
+			"type": "select",
+			"optionLabels": [
+				"mb-0",
+				"mb-1",
+				"mb-2",
+				"mb-3",
+				"mb-4",
+				"mb-5",
+				"mb-auto"
+			],
+			"removeDefaultNone": true
+		},
+		"PaddingTop": {
+			"title": "Padding (top)",
+			"type": "select",
+			"optionLabels": [
+				"pt-0",
+				"pt-1",
+				"pt-2",
+				"pt-3",
+				"pt-4",
+				"pt-5",
+				"pt-auto"
+			],
+			"removeDefaultNone": true
+		},
+		"PaddingBottom": {
+			"title": "Padding (bottom)",
+			"type": "select",
+			"optionLabels": [
+				"pb-0",
+				"pb-1",
+				"pb-2",
+				"pb-3",
+				"pb-4",
+				"pb-5",
+				"pb-auto"
+			],
+			"removeDefaultNone": true
+		}	
+
+	}
+}

--- a/Porto-Paragraphs-Random-Side-Image/template-schema.json
+++ b/Porto-Paragraphs-Random-Side-Image/template-schema.json
@@ -1,0 +1,57 @@
+{
+    "type": "object",
+    "properties": {        
+        "MarginTop": {
+            "title": "Margin (top)",
+            "type": "string",
+            "enum": [
+				"mt-0",
+				"mt-1",
+				"mt-2",
+				"mt-3",
+				"mt-4",
+				"mt-5",
+				"mt-auto"
+            ]
+        },
+        "MarginBottom": {
+            "title": "Margin (bottom)",
+            "type": "string",
+            "enum": [
+				"mb-0",
+				"mb-1",
+				"mb-2",
+				"mb-3",
+				"mb-4",
+				"mb-5",
+				"mb-auto"
+            ]
+        },
+        "PaddingTop": {
+            "title": "Padding (top)",
+            "type": "string",
+            "enum": [
+				"pt-0",
+				"pt-1",
+				"pt-2",
+				"pt-3",
+				"pt-4",
+				"pt-5",
+				"pt-auto"
+            ]
+        },
+        "PaddingBottom": {
+            "title": "Padding (bottom)",
+            "type": "string",
+            "enum": [
+				"pb-0",
+				"pb-1",
+				"pb-2",
+				"pb-3",
+				"pb-4",
+				"pb-5",
+				"pb-auto"
+            ]
+        }
+    }
+}

--- a/Porto-Paragraphs-Random-Side-Image/view.json
+++ b/Porto-Paragraphs-Random-Side-Image/view.json
@@ -1,0 +1,10 @@
+{
+  "parent": "dnnbootstrap-edit-horizontal",
+  "layout": {
+    "template": "<div><div class=\"row\"><div class=\"col-md-6\" id=\"pos_1_1\"></div><div class=\"col-md-6\" id=\"pos_1_2\"></div></div></div>",
+    "bindings": {
+      "Paragraph": "#pos_1_1",
+      "Images": "#pos_1_2"
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #71  

## Description
Based off of the `Porto-Paragraphs-Side-Image` template, allows a content editor to add rich text/paragraph content next to a main image, which is chosen randomly based on the images saved by the content editor.  

## How Has This Been Tested?
Locally and in production.  

## Screenshots (if appropriate):
None  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.