### PR TITLE
Features/new template

### DIFF
--- a/Upendo-Events-Detail/Template.cshtml
+++ b/Upendo-Events-Detail/Template.cshtml
@@ -12,6 +12,8 @@
 @inherits Satrabel.OpenContent.Components.OpenContentWebPage
 
 @functions {
+    public const string EventTagQueryStringKey = "eventTag";
+
     public string GetSafeString(object value)
     {
         return value == null ? string.Empty : Convert.ToString(value);
@@ -47,6 +49,41 @@
         }
 
         return defaultValue;
+    }
+
+    public string GetFeatureIconClass(string iconClass)
+    {
+        if (string.IsNullOrWhiteSpace(iconClass))
+        {
+            return string.Empty;
+        }
+
+        string normalized = iconClass.Trim();
+        foreach (char c in normalized)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '-' && c != '_' && c != ' ')
+            {
+                return string.Empty;
+            }
+        }
+
+        if (normalized.IndexOf("fa-", StringComparison.OrdinalIgnoreCase) < 0)
+        {
+            return string.Empty;
+        }
+
+        bool hasStyleClass = normalized.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(x => string.Equals(x, "fa", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "fas", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "far", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "fal", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "fab", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "fa-solid", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "fa-regular", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "fa-light", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(x, "fa-brands", StringComparison.OrdinalIgnoreCase));
+
+        return hasStyleClass ? normalized : "fas " + normalized;
     }
 }
 
@@ -274,6 +311,11 @@
     string imageAbsoluteUrl = TemplateHelper.BuildAbsoluteUrl(imageUrl);
     string imageAltText = EventFormattingHelper.GetImageAltText(evt);
     string venueAddressText = evt.Venue != null ? EventFormattingHelper.GetVenueAddressText(evt.Venue) : string.Empty;
+    bool hasRegistrationCta = !string.IsNullOrWhiteSpace(evt.RegistrationUrl);
+    bool hasSecondaryCta = !string.IsNullOrWhiteSpace(evt.SecondaryCtaUrl);
+    string registrationButtonText = string.IsNullOrWhiteSpace(evt.RegistrationButtonText) ? "Register" : evt.RegistrationButtonText;
+    string secondaryCtaText = string.IsNullOrWhiteSpace(evt.SecondaryCtaText) ? "Learn More" : evt.SecondaryCtaText;
+    bool hasAnyCta = hasRegistrationCta || hasSecondaryCta || !string.IsNullOrWhiteSpace(vm.IcsDownloadUrl);
 
     bool hasMapCoordinates = evt != null
         && evt.Venue != null
@@ -345,7 +387,7 @@
                         <nav aria-label="Tags for this event" class="d-flex flex-wrap gap-2">
                             @foreach (var tag in evt.Tags)
                             {
-                                <a href="@EventPageUrlHelper.BuildListPageUrl(listPagePath)?tag=@HttpUtility.UrlEncode(tag.Slug)" class="tag-chip">
+                                <a href="@EventPageUrlHelper.BuildListPageUrl(listPagePath)?@EventTagQueryStringKey=@HttpUtility.UrlEncode(tag.Slug)" class="tag-chip">
                                     #@tag.TagName
                                 </a>
                             }
@@ -441,16 +483,26 @@
                     </div>
                 }
 
-                @if (!string.IsNullOrWhiteSpace(evt.RegistrationUrl) || !string.IsNullOrWhiteSpace(vm.IcsDownloadUrl))
+                @if (hasAnyCta)
                 {
                     <div class="event-cta-row">
-                        @if (!string.IsNullOrWhiteSpace(evt.RegistrationUrl))
+                        @if (hasRegistrationCta)
                         {
                             <a href="@evt.RegistrationUrl"
                                class="btn btn-primary"
                                target="_blank"
                                rel="noopener noreferrer">
-                                @(string.IsNullOrWhiteSpace(evt.RegistrationButtonText) ? "Register" : evt.RegistrationButtonText)
+                                @registrationButtonText
+                            </a>
+                        }
+
+                        @if (hasSecondaryCta)
+                        {
+                            <a href="@evt.SecondaryCtaUrl"
+                               class="btn btn-outline-secondary"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                @secondaryCtaText
                             </a>
                         }
 
@@ -503,6 +555,17 @@
                                 <div class="col-12 col-md-6">
                                     <div class="card event-feature-card border-0">
                                         <div class="card-body">
+                                            @{
+                                                string featureIconClass = GetFeatureIconClass(feature.IconClass);
+                                            }
+
+                                            @if (!string.IsNullOrWhiteSpace(featureIconClass))
+                                            {
+                                                <div class="event-feature-icon" aria-hidden="true">
+                                                    <i class="@featureIconClass"></i>
+                                                </div>
+                                            }
+
                                             @if (!string.IsNullOrWhiteSpace(feature.Title))
                                             {
                                                 <h3 class="h6 mb-2">@feature.Title</h3>
@@ -646,14 +709,22 @@
 
                     </ul>
 
-                    @if (!string.IsNullOrWhiteSpace(evt.RegistrationUrl) || !string.IsNullOrWhiteSpace(vm.IcsDownloadUrl))
+                    @if (hasAnyCta)
                     {
                         <div class="d-grid gap-2 mt-4">
-                            @if (!string.IsNullOrWhiteSpace(evt.RegistrationUrl))
+                            @if (hasRegistrationCta)
                             {
                                 <a href="@evt.RegistrationUrl" class="btn btn-primary" target="_blank" rel="noopener noreferrer"
-                                    aria-label="@(string.IsNullOrWhiteSpace(evt.RegistrationButtonText) ? "Register for " + evt.Title : evt.RegistrationButtonText + " for " + evt.Title)">
-                                        @(string.IsNullOrWhiteSpace(evt.RegistrationButtonText) ? "Register" : evt.RegistrationButtonText)
+                                    aria-label="@registrationButtonText for @evt.Title">
+                                        @registrationButtonText
+                                </a>
+                            }
+
+                            @if (hasSecondaryCta)
+                            {
+                                <a href="@evt.SecondaryCtaUrl" class="btn btn-outline-secondary" target="_blank" rel="noopener noreferrer"
+                                    aria-label="@secondaryCtaText for @evt.Title">
+                                        @secondaryCtaText
                                 </a>
                             }
 

--- a/Upendo-Events-Detail/template.css
+++ b/Upendo-Events-Detail/template.css
@@ -402,6 +402,24 @@
     padding: 1rem;
 }
 
+.event-feature-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    margin-bottom: 0.85rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(var(--bs-primary-rgb), 0.1);
+    color: var(--bs-primary);
+    box-shadow: inset 0 0 0 1px rgba(var(--bs-primary-rgb), 0.2);
+}
+
+.event-feature-icon i {
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
 .event-related-card img {
     width: 100%;
     height: 200px;

--- a/Upendo-Events-List/Template.cshtml
+++ b/Upendo-Events-List/Template.cshtml
@@ -12,6 +12,9 @@
 @inherits Satrabel.OpenContent.Components.OpenContentWebPage
 
 @functions {
+    public const string EventTagQueryStringKey = "eventTag";
+    public const string LegacyTagQueryStringKey = "tag";
+
     public string GetSectionHeading(EventListRequest request)
     {
         if (request != null && !request.IsUpcoming)
@@ -35,6 +38,83 @@
         }
 
         return results.TotalRows.ToString() + " events found.";
+    }
+
+    public string BuildEventsFilterUrl(EventListRequest request, string categorySlug)
+    {
+        var query = HttpUtility.ParseQueryString(string.Empty);
+
+        bool isUpcoming = request == null || request.IsUpcoming;
+        query["upcoming"] = isUpcoming ? "true" : "false";
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.TagSlug))
+        {
+            query[EventTagQueryStringKey] = request.TagSlug;
+        }
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.OrganizerSlug))
+        {
+            query["organizer"] = request.OrganizerSlug;
+        }
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.Keyword))
+        {
+            query["q"] = request.Keyword;
+        }
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.SortBy))
+        {
+            query["sort"] = request.SortBy;
+        }
+
+        if (!string.IsNullOrWhiteSpace(categorySlug))
+        {
+            query["category"] = categorySlug;
+        }
+
+        string qs = query.ToString();
+        return string.IsNullOrWhiteSpace(qs) ? "?" : "?" + qs;
+    }
+
+    public string BuildEventsPageUrl(EventListRequest request, int pageNumber)
+    {
+        var query = HttpUtility.ParseQueryString(string.Empty);
+
+        bool isUpcoming = request == null || request.IsUpcoming;
+        query["upcoming"] = isUpcoming ? "true" : "false";
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.CategorySlug))
+        {
+            query["category"] = request.CategorySlug;
+        }
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.TagSlug))
+        {
+            query[EventTagQueryStringKey] = request.TagSlug;
+        }
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.OrganizerSlug))
+        {
+            query["organizer"] = request.OrganizerSlug;
+        }
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.Keyword))
+        {
+            query["q"] = request.Keyword;
+        }
+
+        if (request != null && !string.IsNullOrWhiteSpace(request.SortBy))
+        {
+            query["sort"] = request.SortBy;
+        }
+
+        if (pageNumber > 1)
+        {
+            query["page"] = pageNumber.ToString(CultureInfo.InvariantCulture);
+        }
+
+        string qs = query.ToString();
+        return string.IsNullOrWhiteSpace(qs) ? "?" : "?" + qs;
     }
 }
 
@@ -151,7 +231,11 @@
     }
 
     string categorySlug = httpRequest != null ? httpRequest.QueryString["category"] : null;
-    string tagSlug = httpRequest != null ? httpRequest.QueryString["tag"] : null;
+    string tagSlug = httpRequest != null ? httpRequest.QueryString[EventTagQueryStringKey] : null;
+    if (string.IsNullOrWhiteSpace(tagSlug) && httpRequest != null)
+    {
+        tagSlug = httpRequest.QueryString[LegacyTagQueryStringKey];
+    }
     string organizerSlug = httpRequest != null ? httpRequest.QueryString["organizer"] : null;
     string keyword = httpRequest != null ? httpRequest.QueryString["q"] : null;
     string sortBy = httpRequest != null ? httpRequest.QueryString["sort"] : null;
@@ -210,7 +294,7 @@
             <h2 class="event-section-heading h5 mb-3">Browse by Category</h2>
 
             <div class="event-chip-row">
-                <a href="@EventRequestHelper.BuildFilterUrl(request, null)"
+                <a href="@BuildEventsFilterUrl(request, null)"
                 class="category-chip @(string.IsNullOrEmpty(vm.ActiveCategorySlug) ? "active" : "")"
                 aria-current="@(string.IsNullOrEmpty(vm.ActiveCategorySlug) ? "page" : null)">
                     All
@@ -220,7 +304,7 @@
                 {
                     bool isActive = vm.ActiveCategorySlug == cat.CategorySlug;
 
-                    <a href="@EventRequestHelper.BuildFilterUrl(request, cat.CategorySlug)"
+                    <a href="@BuildEventsFilterUrl(request, cat.CategorySlug)"
                     class="category-chip @(isActive ? "active" : "")"
                     aria-current="@(isActive ? "page" : null)">
                         @cat.CategoryName
@@ -352,7 +436,7 @@
                                         <nav class="event-chip-row mb-0" aria-label="Tags for @item.Title">
                                             @foreach (var tag in item.Tags)
                                             {
-                                                <a href="?tag=@HttpUtility.UrlEncode(tag.Slug)" class="tag-chip">
+                                                <a href="?@EventTagQueryStringKey=@HttpUtility.UrlEncode(tag.Slug)" class="tag-chip">
                                                     #@tag.TagName
                                                 </a>
                                             }
@@ -394,7 +478,7 @@
                                 @for (int i = 1; i <= results.TotalPages; i++)
                                 {
                                     <li class="page-item @(i == results.PageNumber ? "active" : "")">
-                                        <a class="page-link" href="@EventRequestHelper.BuildPageUrl(request, i)" aria-current="@(i == results.PageNumber ? "page" : null)" aria-label="Page @i">
+                                        <a class="page-link" href="@BuildEventsPageUrl(request, i)" aria-current="@(i == results.PageNumber ? "page" : null)" aria-label="Page @i">
                                             @i
                                         </a>
                                     </li>
@@ -418,7 +502,7 @@
                     <div class="event-chip-row">
                         @foreach (var tag in vm.TrendingTags)
                         {
-                            <a href="?tag=@tag.Slug" class="topic-chip">
+                            <a href="?@EventTagQueryStringKey=@HttpUtility.UrlEncode(tag.Slug)" class="topic-chip">
                                 #@tag.TagName
                             </a>
                         }

--- a/Upendo-Events-List/template.css
+++ b/Upendo-Events-List/template.css
@@ -402,6 +402,24 @@
     padding: 1rem;
 }
 
+.event-feature-icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    margin-bottom: 0.85rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(var(--bs-primary-rgb), 0.1);
+    color: var(--bs-primary);
+    box-shadow: inset 0 0 0 1px rgba(var(--bs-primary-rgb), 0.2);
+}
+
+.event-feature-icon i {
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
 .event-related-card img {
     width: 100%;
     height: 200px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #102

## Description
This PR improves the public Events templates so event pages are more flexible, easier to navigate, and better aligned with how clients promote real events.

At a business level, these updates help event pages support more visitor actions, make filters more reliable when multiple templates or modules exist on a page, and add more visual polish to the event detail experience.

### Secondary CTA support on event detail pages

The event detail template now displays the secondary call-to-action when an event has a Secondary CTA URL configured.

Previously, the management experience allowed a secondary CTA to be entered, but the public event detail template only displayed the primary registration CTA and the Add to Calendar action. This created a mismatch between what site managers entered and what visitors could actually see.

The detail page now supports the secondary CTA in both primary conversion areas:

- The hero CTA row near the event title and summary.
- The Key Details CTA stack in the sidebar.

The CTA rendering is defensive and avoids empty or broken buttons:

- The primary CTA only appears when a Registration URL exists.
- The secondary CTA only appears when a Secondary CTA URL exists.
- The primary CTA uses the configured Registration Button Text, with `Register` as a fallback.
- The secondary CTA uses the configured Secondary CTA Text, with `Learn More` as a fallback.
- The Add to Calendar action continues to appear when an ICS download URL is available.

This gives clients more flexibility for common event needs, such as Reserve your spot, Contact organizer, Learn more, Join waitlist, Donate, Sponsor this event, or View supporting details.

### Safer event tag query-string behavior

The Events templates now use `eventTag` as the public query-string key for event tag filtering instead of relying only on `tag`.

This helps avoid conflicts with other search, listing, blog, directory, or page-level templates that may also use a generic `tag` key. The detail template now links tags back to the list page using `eventTag`, and the list template uses `eventTag` when building tag links.

For compatibility, the list template still falls back to the legacy `tag` query-string value when `eventTag` is not present. This allows older event tag links to continue working while moving the public template behavior toward a more specific and safer query-string key.

### More reliable filter and pagination links

The list template now builds category filter links and pagination links within the template using event-specific helper methods.

This keeps important state in place when visitors browse the event list, including:

- Upcoming/past event mode.
- Active category.
- Active event tag.
- Active organizer.
- Keyword search.
- Sort order.
- Page number.

This helps prevent user frustration where selecting a category, changing pages, or clicking a tag accidentally drops other active filters.

### Event feature icon support

The event detail template now supports optional feature icons when event features include a valid Font Awesome-style icon class.

The icon helper validates the icon class before rendering it, which helps avoid unsafe or malformed class output. If an icon class is valid but does not include a style prefix, the template applies a safe default style prefix.

Feature icons also received supporting CSS so they appear as small, polished circular badges above feature card content. This gives event detail pages a more finished and scannable presentation without requiring every feature to have an icon.

### CSS polish for feature cards

The detail template stylesheet now includes styling for `.event-feature-icon` and the icon element inside it.

This adds consistent sizing, spacing, alignment, color, and a subtle inset border treatment so feature icons feel integrated with the existing template design.

## How Has This Been Tested?
Local dev and production.

Additional recommended verification before merge:

- Confirm an event with only a primary CTA still shows the primary CTA and Add to Calendar action as expected.
- Confirm an event with both primary and secondary CTAs shows both CTA buttons in the hero area.
- Confirm an event with both primary and secondary CTAs shows both CTA buttons in the Key Details sidebar.
- Confirm an event with a secondary CTA URL but no secondary CTA text uses the `Learn More` fallback label.
- Confirm no secondary CTA button appears when no secondary CTA URL is configured.
- Confirm event tag links from the detail page use `eventTag`.
- Confirm event tag links on the list page use `eventTag`.
- Confirm existing legacy links using `tag` still filter the event list.
- Confirm category filters preserve other active filters where applicable.
- Confirm pagination preserves active filter state.
- Confirm event feature icons render when valid icon classes exist.
- Confirm event feature cards still render cleanly when no icon class is provided.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.