### PR TITLE
Add Upendo Marquee Section template

### DIFF
--- a/Upendo-Marquee-Section/data.json
+++ b/Upendo-Marquee-Section/data.json
@@ -1,0 +1,72 @@
+{
+  "ModuleTitle": "Marquee Section",
+  "ModuleAnchor": "",
+  "Items": [
+    {
+      "ItemLabel": "Strategy",
+      "ItemType": "text-icon",
+      "Text": "Strategy",
+      "IconClass": "fas fa-compass",
+      "LogoImage": "",
+      "WithLink": false,
+      "LinkUrl": "",
+      "LinkTarget": "_self",
+      "AriaLabel": ""
+    },
+    {
+      "ItemLabel": "Automation",
+      "ItemType": "text-icon",
+      "Text": "Automation",
+      "IconClass": "fas fa-cogs",
+      "LogoImage": "",
+      "WithLink": false,
+      "LinkUrl": "",
+      "LinkTarget": "_self",
+      "AriaLabel": ""
+    },
+    {
+      "ItemLabel": "Integrations",
+      "ItemType": "text-icon",
+      "Text": "Integrations",
+      "IconClass": "fas fa-project-diagram",
+      "LogoImage": "",
+      "WithLink": false,
+      "LinkUrl": "",
+      "LinkTarget": "_self",
+      "AriaLabel": ""
+    },
+    {
+      "ItemLabel": "Experience Design",
+      "ItemType": "text-icon",
+      "Text": "Experience Design",
+      "IconClass": "fas fa-palette",
+      "LogoImage": "",
+      "WithLink": false,
+      "LinkUrl": "",
+      "LinkTarget": "_self",
+      "AriaLabel": ""
+    },
+    {
+      "ItemLabel": "AI Enablement",
+      "ItemType": "text-icon",
+      "Text": "AI Enablement",
+      "IconClass": "fas fa-brain",
+      "LogoImage": "",
+      "WithLink": false,
+      "LinkUrl": "",
+      "LinkTarget": "_self",
+      "AriaLabel": ""
+    },
+    {
+      "ItemLabel": "Commerce",
+      "ItemType": "text-icon",
+      "Text": "Commerce",
+      "IconClass": "fas fa-shopping-cart",
+      "LogoImage": "",
+      "WithLink": false,
+      "LinkUrl": "",
+      "LinkTarget": "_self",
+      "AriaLabel": ""
+    }
+  ]
+}

--- a/Upendo-Marquee-Section/options.json
+++ b/Upendo-Marquee-Section/options.json
@@ -1,0 +1,97 @@
+{
+  "fields": {
+    "ModuleTitle": {
+      "type": "text",
+      "helper": "Administrator-facing title for this content block. Used as an accessible label for the marquee section.",
+      "placeholder": "Marquee Section"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Optional. Used to create #anchor-links on the page. Letters, numbers, and hyphens only.",
+      "placeholder": "marquee-section",
+      "showMessages": false
+    },
+    "Items": {
+      "type": "accordion",
+      "titleField": "ItemLabel",
+      "helper": "Add as many marquee items as needed. Items display in the order shown here.",
+      "items": {
+        "fields": {
+          "ItemLabel": {
+            "type": "text",
+            "helper": "Editor-only label shown in the Marquee Items accordion header.",
+            "placeholder": "Item"
+          },
+          "ItemType": {
+            "type": "select",
+            "helper": "Choose whether this marquee item renders as text with an optional icon or as a standalone logo image.",
+            "optionLabels": ["Text + Icon", "Logo Image"],
+            "removeDefaultNone": true
+          },
+          "Text": {
+            "type": "text",
+            "helper": "Visible text for the item.",
+            "placeholder": "Solution Accelerator",
+            "dependencies": {
+              "ItemType": [
+                "text-icon"
+              ]
+            }
+          },
+          "IconClass": {
+            "type": "text",
+            "helper": "Optional icon class if the active theme supports icon fonts. Example: <code>fas fa-bolt</code>.",
+            "placeholder": "fas fa-bolt",
+            "dependencies": {
+              "ItemType": [
+                "text-icon"
+              ]
+            }
+          },
+          "LogoImage": {
+            "type": "image",
+            "uploadfolder": "Content/Logos/",
+            "typeahead": {
+              "Folder": "Content/Logos/"
+            },
+            "helper": "Logo image for this item. Use SVG or transparent PNG when possible.",
+            "dependencies": {
+              "ItemType": [
+                "logo-image"
+              ]
+            }
+          },
+          "WithLink": {
+            "type": "checkbox",
+            "helper": "Enable this when the item should link to another page or external URL."
+          },
+          "LinkUrl": {
+            "type": "url",
+            "helper": "Destination URL for this item.",
+            "dependencies": {
+              "WithLink": [
+                true
+              ]
+            }
+          },
+          "LinkTarget": {
+            "type": "select",
+            "helper": "Choose whether the optional link opens in the current browser tab or a new browser tab.",
+            "optionLabels": ["Current Tab", "New Tab"],
+            "removeDefaultNone": true,
+            "dependencies": {
+              "WithLink": [
+                true
+              ]
+            }
+          },
+          "AriaLabel": {
+            "type": "text",
+            "helper": "Optional accessible label. Useful when an item is only a logo or when link text needs extra context.",
+            "placeholder": "Learn more about Solution Accelerator"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Upendo-Marquee-Section/schema.json
+++ b/Upendo-Marquee-Section/schema.json
@@ -1,0 +1,71 @@
+{
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+      "pattern": "^$|^[a-zA-Z0-9\\-]+$"
+    },
+    "Items": {
+      "type": "array",
+      "title": "Marquee Items",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ItemLabel": {
+            "type": "string",
+            "title": "Item Label",
+            "default": "Item"
+          },
+          "ItemType": {
+            "type": "string",
+            "title": "Item Type",
+            "default": "text-icon",
+            "enum": ["text-icon", "logo-image"]
+          },
+          "Text": {
+            "type": "string",
+            "title": "Text",
+            "dependencies": ["ItemType"]
+          },
+          "IconClass": {
+            "type": "string",
+            "title": "Icon Class",
+            "dependencies": ["ItemType"]
+          },
+          "LogoImage": {
+            "type": "string",
+            "title": "Logo Image",
+            "dependencies": ["ItemType"]
+          },
+          "WithLink": {
+            "type": "boolean",
+            "title": "With Link",
+            "default": false
+          },
+          "LinkUrl": {
+            "type": "string",
+            "title": "Link URL",
+            "dependencies": ["WithLink"]
+          },
+          "LinkTarget": {
+            "type": "string",
+            "title": "Link Target",
+            "default": "_self",
+            "enum": ["_self", "_blank"],
+            "dependencies": ["WithLink"]
+          },
+          "AriaLabel": {
+            "type": "string",
+            "title": "Aria Label"
+          }
+        }
+      }
+    }
+  },
+  "required": ["Items"]
+}

--- a/Upendo-Marquee-Section/template-data.json
+++ b/Upendo-Marquee-Section/template-data.json
@@ -1,0 +1,16 @@
+{
+  "BackgroundColor": "#050505",
+  "TextColor": "#f8fafc",
+  "TextSize": "medium",
+  "LogoHeight": "32px",
+  "ItemGap": "3rem",
+  "SectionPaddingY": "1rem",
+  "MarqueeSpeed": "45s",
+  "Direction": "left",
+  "PauseOnHover": true,
+  "FadeEdges": true,
+  "MarginTop": "mt-auto",
+  "MarginBottom": "mb-auto",
+  "PaddingTop": "pt-auto",
+  "PaddingBottom": "pb-auto"
+}

--- a/Upendo-Marquee-Section/template-options.json
+++ b/Upendo-Marquee-Section/template-options.json
@@ -1,0 +1,84 @@
+{
+  "fields": {
+    "BackgroundColor": {
+      "type": "select",
+      "helper": "Background color for the full-width marquee band.",
+      "optionLabels": ["Black", "Navy Blue", "White", "Transparent"],
+      "removeDefaultNone": true
+    },
+    "TextColor": {
+      "type": "select",
+      "helper": "Color used for text and icon font items. Logo images keep their original colors.",
+      "optionLabels": ["Near White", "White", "Light Gray", "Near Black", "Navy Blue"],
+      "removeDefaultNone": true
+    },
+    "TextSize": {
+      "type": "select",
+      "helper": "Controls the visible item text and icon size.",
+      "optionLabels": ["Small", "Medium", "Large"],
+      "removeDefaultNone": true
+    },
+    "LogoHeight": {
+      "type": "select",
+      "helper": "Maximum displayed height for logo images.",
+      "optionLabels": ["24px", "32px", "40px", "56px"],
+      "removeDefaultNone": true
+    },
+    "ItemGap": {
+      "type": "select",
+      "helper": "Horizontal spacing between marquee items.",
+      "optionLabels": ["2rem", "3rem", "4rem", "5rem"],
+      "removeDefaultNone": true
+    },
+    "SectionPaddingY": {
+      "type": "select",
+      "helper": "Top and bottom padding inside the marquee band.",
+      "optionLabels": ["0.75rem", "1rem", "1.5rem", "2rem"],
+      "removeDefaultNone": true
+    },
+    "MarqueeSpeed": {
+      "type": "select",
+      "helper": "Animation duration for one marquee cycle. Higher values move more slowly.",
+      "optionLabels": ["20s Fast", "30s", "45s Default", "60s", "90s Slow"],
+      "removeDefaultNone": true
+    },
+    "Direction": {
+      "type": "select",
+      "helper": "Direction the marquee moves.",
+      "optionLabels": ["Left", "Right"],
+      "removeDefaultNone": true
+    },
+    "PauseOnHover": {
+      "type": "checkbox",
+      "helper": "Pause the animation when visitors hover over the marquee or focus a link."
+    },
+    "FadeEdges": {
+      "type": "checkbox",
+      "helper": "Softly fade the left and right edges of the marquee."
+    },
+    "MarginTop": {
+      "title": "Margin (top)",
+      "type": "select",
+      "optionLabels": ["mt-0", "mt-1", "mt-2", "mt-3", "mt-4", "mt-5", "mt-auto"],
+      "removeDefaultNone": true
+    },
+    "MarginBottom": {
+      "title": "Margin (bottom)",
+      "type": "select",
+      "optionLabels": ["mb-0", "mb-1", "mb-2", "mb-3", "mb-4", "mb-5", "mb-auto"],
+      "removeDefaultNone": true
+    },
+    "PaddingTop": {
+      "title": "Padding (top)",
+      "type": "select",
+      "optionLabels": ["pt-0", "pt-1", "pt-2", "pt-3", "pt-4", "pt-5", "pt-auto"],
+      "removeDefaultNone": true
+    },
+    "PaddingBottom": {
+      "title": "Padding (bottom)",
+      "type": "select",
+      "optionLabels": ["pb-0", "pb-1", "pb-2", "pb-3", "pb-4", "pb-5", "pb-auto"],
+      "removeDefaultNone": true
+    }
+  }
+}

--- a/Upendo-Marquee-Section/template-schema.json
+++ b/Upendo-Marquee-Section/template-schema.json
@@ -1,0 +1,73 @@
+{
+  "type": "object",
+  "properties": {
+    "BackgroundColor": {
+      "type": "string",
+      "title": "Background Color",
+      "enum": ["#050505", "#01233F", "#ffffff", "transparent"]
+    },
+    "TextColor": {
+      "type": "string",
+      "title": "Text and Icon Color",
+      "enum": ["#f8fafc", "#ffffff", "#d1d5db", "#111827", "#01233F"]
+    },
+    "TextSize": {
+      "type": "string",
+      "title": "Text Size",
+      "enum": ["small", "medium", "large"]
+    },
+    "LogoHeight": {
+      "type": "string",
+      "title": "Logo Height",
+      "enum": ["24px", "32px", "40px", "56px"]
+    },
+    "ItemGap": {
+      "type": "string",
+      "title": "Item Gap",
+      "enum": ["2rem", "3rem", "4rem", "5rem"]
+    },
+    "SectionPaddingY": {
+      "type": "string",
+      "title": "Section Vertical Padding",
+      "enum": ["0.75rem", "1rem", "1.5rem", "2rem"]
+    },
+    "MarqueeSpeed": {
+      "type": "string",
+      "title": "Marquee Speed",
+      "enum": ["20s", "30s", "45s", "60s", "90s"]
+    },
+    "Direction": {
+      "type": "string",
+      "title": "Direction",
+      "enum": ["left", "right"]
+    },
+    "PauseOnHover": {
+      "type": "boolean",
+      "title": "Pause on Hover or Focus"
+    },
+    "FadeEdges": {
+      "type": "boolean",
+      "title": "Fade Edges"
+    },
+    "MarginTop": {
+      "title": "Margin (top)",
+      "type": "string",
+      "enum": ["mt-0", "mt-1", "mt-2", "mt-3", "mt-4", "mt-5", "mt-auto"]
+    },
+    "MarginBottom": {
+      "title": "Margin (bottom)",
+      "type": "string",
+      "enum": ["mb-0", "mb-1", "mb-2", "mb-3", "mb-4", "mb-5", "mb-auto"]
+    },
+    "PaddingTop": {
+      "title": "Padding (top)",
+      "type": "string",
+      "enum": ["pt-0", "pt-1", "pt-2", "pt-3", "pt-4", "pt-5", "pt-auto"]
+    },
+    "PaddingBottom": {
+      "title": "Padding (bottom)",
+      "type": "string",
+      "enum": ["pb-0", "pb-1", "pb-2", "pb-3", "pb-4", "pb-5", "pb-auto"]
+    }
+  }
+}

--- a/Upendo-Marquee-Section/template.cshtml
+++ b/Upendo-Marquee-Section/template.cshtml
@@ -1,0 +1,293 @@
+@using System
+@using System.Collections.Generic
+@using System.Text
+@using System.Web
+@using Upendo.Libraries.RunsOnUpendoCore.Helpers
+@inherits Satrabel.OpenContent.Components.OpenContentWebPage
+
+@functions {
+    private static string GetString(dynamic value, string fallback = "")
+    {
+        if (value == null)
+        {
+            return fallback;
+        }
+
+        var text = Convert.ToString(value);
+        return string.IsNullOrWhiteSpace(text) ? fallback : text;
+    }
+
+    private static object GetValue(dynamic source, string propertyName)
+    {
+        if (source == null)
+        {
+            return null;
+        }
+
+        var dictionary = source as IDictionary<string, object>;
+        if (dictionary != null && dictionary.ContainsKey(propertyName))
+        {
+            return dictionary[propertyName];
+        }
+
+        try
+        {
+            return source[propertyName];
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            var property = ((object)source).GetType().GetProperty(propertyName);
+            return property == null ? null : property.GetValue(source, null);
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    private static bool GetBool(dynamic value, bool fallback = false)
+    {
+        if (value == null)
+        {
+            return fallback;
+        }
+
+        bool parsed;
+        return bool.TryParse(Convert.ToString(value), out parsed) ? parsed : fallback;
+    }
+
+    private static string GetAllowedString(dynamic value, string fallback, params string[] allowedValues)
+    {
+        var text = GetString(value, fallback);
+
+        foreach (var allowedValue in allowedValues)
+        {
+            if (text.Equals(allowedValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return allowedValue;
+            }
+        }
+
+        return fallback;
+    }
+
+    private static string GetImageUrl(dynamic image)
+    {
+        if (image == null)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            if (image.Url != null)
+            {
+                return Convert.ToString(image.Url);
+            }
+        }
+        catch
+        {
+        }
+
+        return Convert.ToString(image);
+    }
+
+    private static string GetLinkAttributes(string linkTarget)
+    {
+        return linkTarget.Equals("_blank", StringComparison.OrdinalIgnoreCase)
+            ? " target=\"_blank\" rel=\"noopener noreferrer\""
+            : string.Empty;
+    }
+
+    private static IHtmlString RenderMarqueeItem(dynamic item, bool renderAsClone = false)
+    {
+        var text = GetString(GetValue(item, "Text"));
+        var iconClass = GetString(GetValue(item, "IconClass"));
+        var logoImageValue = GetValue(item, "LogoImage");
+        var logoImage = logoImageValue != null ? GetImageUrl(logoImageValue) : string.Empty;
+        var linkUrl = GetString(GetValue(item, "LinkUrl"));
+        var linkTarget = GetAllowedString(GetValue(item, "LinkTarget"), "_self", "_self", "_blank");
+        var ariaLabel = GetString(GetValue(item, "AriaLabel"));
+        var hasText = !string.IsNullOrWhiteSpace(text);
+        var hasIcon = !string.IsNullOrWhiteSpace(iconClass);
+        var hasLogo = !string.IsNullOrWhiteSpace(logoImage);
+        var itemType = GetString(GetValue(item, "ItemType"));
+        var withLink = GetValue(item, "WithLink");
+        var withLinkValue = GetString(withLink);
+        var hasExplicitItemType = !string.IsNullOrWhiteSpace(itemType);
+        var isLogoImageItem = itemType.Equals("logo-image", StringComparison.OrdinalIgnoreCase)
+            || (!hasExplicitItemType && hasLogo && !hasText && !hasIcon);
+        var isTextIconItem = !isLogoImageItem;
+        var hasLink = !string.IsNullOrWhiteSpace(linkUrl)
+            && (string.IsNullOrWhiteSpace(withLinkValue) || GetBool(withLink, false));
+
+        if ((isLogoImageItem && !hasLogo) || (isTextIconItem && !hasText && !hasIcon))
+        {
+            return new HtmlString(string.Empty);
+        }
+
+        var content = new StringBuilder();
+        if (isLogoImageItem)
+        {
+            var imageAlt = hasText ? string.Empty : ariaLabel;
+            content.Append("<img class=\"oc-ms-logo\" src=\"")
+                .Append(HttpUtility.HtmlAttributeEncode(logoImage))
+                .Append("\" alt=\"")
+                .Append(HttpUtility.HtmlAttributeEncode(imageAlt))
+                .Append("\" loading=\"lazy\" />");
+        }
+        else if (hasIcon)
+        {
+            content.Append("<i class=\"oc-ms-icon ")
+                .Append(HttpUtility.HtmlAttributeEncode(iconClass))
+                .Append("\" aria-hidden=\"true\"></i>");
+        }
+
+        if (isTextIconItem && hasText)
+        {
+            content.Append("<span class=\"oc-ms-text\">")
+                .Append(HttpUtility.HtmlEncode(text))
+                .Append("</span>");
+        }
+
+        var labelAttribute = string.IsNullOrWhiteSpace(ariaLabel)
+            ? string.Empty
+            : " aria-label=\"" + HttpUtility.HtmlAttributeEncode(ariaLabel) + "\"";
+
+        if (hasLink)
+        {
+            var cloneAttributes = renderAsClone ? " tabindex=\"-1\"" : string.Empty;
+
+            return new HtmlString(
+                "<a class=\"oc-ms-item oc-ms-item-link\" href=\"" + HttpUtility.HtmlAttributeEncode(linkUrl) + "\"" + GetLinkAttributes(linkTarget) + cloneAttributes + labelAttribute + ">" +
+                content +
+                "</a>");
+        }
+
+        return new HtmlString("<span class=\"oc-ms-item\"" + labelAttribute + ">" + content + "</span>");
+    }
+}
+
+@{
+    TemplateHelper.HideAdminBorder(Model.Context.ModuleId, Model.Context.TabId);
+    RegisterStyleSheet("template.css");
+
+    var moduleTitle = Model.ModuleTitle != null ? Convert.ToString(Model.ModuleTitle) : string.Empty;
+    var moduleAnchor = Model.ModuleAnchor != null ? Convert.ToString(Model.ModuleAnchor) : string.Empty;
+
+    var backgroundColor = Model.Settings != null && Model.Settings.BackgroundColor != null
+        ? GetAllowedString(Model.Settings.BackgroundColor, "#050505", "#050505", "#01233F", "#ffffff", "transparent")
+        : "#050505";
+
+    var textColor = Model.Settings != null && Model.Settings.TextColor != null
+        ? GetAllowedString(Model.Settings.TextColor, "#f8fafc", "#f8fafc", "#ffffff", "#d1d5db", "#111827", "#01233F")
+        : "#f8fafc";
+
+    var textSize = Model.Settings != null && Model.Settings.TextSize != null
+        ? GetAllowedString(Model.Settings.TextSize, "medium", "small", "medium", "large")
+        : "medium";
+
+    var logoHeight = Model.Settings != null && Model.Settings.LogoHeight != null
+        ? GetAllowedString(Model.Settings.LogoHeight, "32px", "24px", "32px", "40px", "56px")
+        : "32px";
+
+    var itemGap = Model.Settings != null && Model.Settings.ItemGap != null
+        ? GetAllowedString(Model.Settings.ItemGap, "3rem", "2rem", "3rem", "4rem", "5rem")
+        : "3rem";
+
+    var sectionPaddingY = Model.Settings != null && Model.Settings.SectionPaddingY != null
+        ? GetAllowedString(Model.Settings.SectionPaddingY, "1rem", "0.75rem", "1rem", "1.5rem", "2rem")
+        : "1rem";
+
+    var marqueeSpeed = Model.Settings != null && Model.Settings.MarqueeSpeed != null
+        ? GetAllowedString(Model.Settings.MarqueeSpeed, "45s", "20s", "30s", "45s", "60s", "90s")
+        : "45s";
+
+    var direction = Model.Settings != null && Model.Settings.Direction != null
+        ? GetAllowedString(Model.Settings.Direction, "left", "left", "right")
+        : "left";
+
+    var pauseOnHover = Model.Settings == null || Model.Settings.PauseOnHover == null
+        ? true
+        : GetBool(Model.Settings.PauseOnHover, true);
+
+    var fadeEdges = Model.Settings == null || Model.Settings.FadeEdges == null
+        ? true
+        : GetBool(Model.Settings.FadeEdges, true);
+
+    var marginTop = Model.Settings != null && Model.Settings.MarginTop != null ? Convert.ToString(Model.Settings.MarginTop) : string.Empty;
+    var marginBottom = Model.Settings != null && Model.Settings.MarginBottom != null ? Convert.ToString(Model.Settings.MarginBottom) : string.Empty;
+    var paddingTop = Model.Settings != null && Model.Settings.PaddingTop != null ? Convert.ToString(Model.Settings.PaddingTop) : string.Empty;
+    var paddingBottom = Model.Settings != null && Model.Settings.PaddingBottom != null ? Convert.ToString(Model.Settings.PaddingBottom) : string.Empty;
+    var marqueeGroupCount = 8;
+
+    var items = new List<dynamic>();
+    if (Model.Items != null)
+    {
+        foreach (var item in Model.Items)
+        {
+            items.Add(item);
+        }
+    }
+
+    var sectionClasses = "oc-marquee-section oc-ms-text-" + textSize;
+    sectionClasses += direction == "right" ? " oc-ms-direction-right" : " oc-ms-direction-left";
+    sectionClasses += pauseOnHover ? " oc-ms-pause-on-hover" : string.Empty;
+    sectionClasses += fadeEdges ? " oc-ms-fade-edges" : string.Empty;
+    if (!string.IsNullOrWhiteSpace(marginTop)) { sectionClasses += " " + marginTop; }
+    if (!string.IsNullOrWhiteSpace(marginBottom)) { sectionClasses += " " + marginBottom; }
+    if (!string.IsNullOrWhiteSpace(paddingTop)) { sectionClasses += " " + paddingTop; }
+    if (!string.IsNullOrWhiteSpace(paddingBottom)) { sectionClasses += " " + paddingBottom; }
+
+    var sectionStyle = "--oc-ms-bg:" + backgroundColor + ";" +
+        "--oc-ms-color:" + textColor + ";" +
+        "--oc-ms-logo-height:" + logoHeight + ";" +
+        "--oc-ms-gap:" + itemGap + ";" +
+        "--oc-ms-padding-y:" + sectionPaddingY + ";" +
+        "--oc-ms-duration:" + marqueeSpeed + ";" +
+        "--oc-ms-loop-shift:-12.5%;";
+
+    var hasAnchor = !string.IsNullOrWhiteSpace(moduleAnchor);
+    var sectionId = "oc-marquee-section-" + Model.Context.ModuleId;
+    var sectionAttributes = string.Empty;
+    if (!string.IsNullOrWhiteSpace(moduleTitle))
+    {
+        sectionAttributes = " aria-label=\"" + HttpUtility.HtmlAttributeEncode(moduleTitle) + "\"";
+    }
+}
+
+@if (hasAnchor)
+{
+    <div id="@moduleAnchor"></div>
+}
+
+@if (items.Count > 0)
+{
+    <section id="@sectionId" class="@sectionClasses"@Html.Raw(sectionAttributes) style="@Html.Raw(sectionStyle)">
+        <div class="oc-ms-viewport">
+            <div class="oc-ms-track">
+                <div class="oc-ms-group">
+                    @foreach (var item in items)
+                    {
+                        @RenderMarqueeItem(item)
+                    }
+                </div>
+
+                @for (var cloneGroupIndex = 1; cloneGroupIndex < marqueeGroupCount; cloneGroupIndex++)
+                {
+                    <div class="oc-ms-group" aria-hidden="true">
+                        @foreach (var item in items)
+                        {
+                            @RenderMarqueeItem(item, true)
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </section>
+}

--- a/Upendo-Marquee-Section/template.css
+++ b/Upendo-Marquee-Section/template.css
@@ -1,0 +1,160 @@
+.oc-marquee-section {
+    --oc-ms-bg: #050505;
+    --oc-ms-color: #f8fafc;
+    --oc-ms-logo-height: 32px;
+    --oc-ms-gap: 3rem;
+    --oc-ms-padding-y: 1rem;
+    --oc-ms-duration: 45s;
+    --oc-ms-loop-shift: -12.5%;
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    padding-top: var(--oc-ms-padding-y);
+    padding-bottom: var(--oc-ms-padding-y);
+    color: var(--oc-ms-color);
+    background: var(--oc-ms-bg);
+}
+
+.oc-marquee-section .oc-ms-viewport {
+    overflow: hidden;
+    width: 100%;
+}
+
+.oc-marquee-section.oc-ms-fade-edges .oc-ms-viewport {
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+}
+
+.oc-marquee-section .oc-ms-track {
+    display: flex;
+    width: max-content;
+    animation: oc-ms-marquee-left var(--oc-ms-duration) linear infinite;
+    will-change: transform;
+}
+
+.oc-marquee-section.oc-ms-direction-right .oc-ms-track {
+    animation-name: oc-ms-marquee-right;
+}
+
+.oc-marquee-section.oc-ms-pause-on-hover:hover .oc-ms-track,
+.oc-marquee-section.oc-ms-pause-on-hover:focus-within .oc-ms-track {
+    animation-play-state: paused;
+}
+
+.oc-marquee-section .oc-ms-group {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    min-width: max-content;
+    gap: var(--oc-ms-gap);
+    padding-right: var(--oc-ms-gap);
+}
+
+.oc-marquee-section .oc-ms-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65em;
+    flex: 0 0 auto;
+    color: var(--oc-ms-color);
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+    white-space: nowrap;
+    opacity: 0.92;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.oc-marquee-section .oc-ms-icon,
+.oc-marquee-section .oc-ms-logo,
+.oc-marquee-section .oc-ms-text {
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.oc-marquee-section .oc-ms-item-link:hover,
+.oc-marquee-section .oc-ms-item-link:focus {
+    color: var(--oc-ms-color);
+    text-decoration: none;
+    opacity: 1;
+}
+
+.oc-marquee-section .oc-ms-item-link:focus {
+    outline: 2px solid currentColor;
+    outline-offset: 0.35rem;
+}
+
+.oc-marquee-section .oc-ms-icon {
+    display: inline-block;
+    color: currentColor;
+    font-size: 1.15em;
+    line-height: 1;
+}
+
+.oc-marquee-section .oc-ms-logo {
+    display: block;
+    width: auto;
+    max-width: 180px;
+    height: var(--oc-ms-logo-height);
+    object-fit: contain;
+}
+
+.oc-marquee-section.oc-ms-text-small .oc-ms-item {
+    font-size: 0.95rem;
+}
+
+.oc-marquee-section.oc-ms-text-medium .oc-ms-item {
+    font-size: 1.15rem;
+}
+
+.oc-marquee-section.oc-ms-text-large .oc-ms-item {
+    font-size: 1.45rem;
+}
+
+@keyframes oc-ms-marquee-left {
+    from {
+        transform: translate3d(0, 0, 0);
+    }
+
+    to {
+        transform: translate3d(var(--oc-ms-loop-shift), 0, 0);
+    }
+}
+
+@keyframes oc-ms-marquee-right {
+    from {
+        transform: translate3d(var(--oc-ms-loop-shift), 0, 0);
+    }
+
+    to {
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@media (max-width: 767px) {
+    .oc-marquee-section {
+        --oc-ms-gap: min(var(--oc-ms-gap), 2rem);
+    }
+
+    .oc-marquee-section.oc-ms-text-large .oc-ms-item {
+        font-size: 1.2rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .oc-marquee-section .oc-ms-viewport {
+        overflow-x: auto;
+        -webkit-mask-image: none;
+        mask-image: none;
+    }
+
+    .oc-marquee-section .oc-ms-track {
+        animation: none;
+        width: auto;
+    }
+
+    .oc-marquee-section .oc-ms-group[aria-hidden="true"] {
+        display: none;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #

## Description
<!--- Describe your changes in detail -->
Adds a new `Upendo-Marquee-Section` OpenContent template.

The template supports:
- Text/icon marquee items
- Logo image marquee items
- Optional item links
- Configurable colors, sizing, spacing, speed, direction, and vertical padding
- Pause-on-hover/focus behavior
- Fade-edge styling
- Reduced-motion fallback behavior

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Reviewed the working tree and inspected the new template files. Confirmed the JSON files parse successfully and compared the file structure against nearby Upendo templates.


## Screenshots (if appropriate):
<img width="1841" height="138" alt="image" src="https://github.com/user-attachments/assets/f9433145-a35a-4440-8514-73c0cbee13ee" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.