### PR TITLE
Add Related Evaluation Paths Orbit Template

### DIFF
--- a/Upendo-Related-Evaluation-Paths-Orbit/data.json
+++ b/Upendo-Related-Evaluation-Paths-Orbit/data.json
@@ -1,0 +1,103 @@
+{
+  "ModuleTitle": "Related Evaluation Paths Orbit",
+  "ModuleAnchor": "related-evaluation-paths",
+  "SectionEyebrow": "",
+  "SectionHeading": "Related evaluation paths",
+  "IntroText": "",
+  "CentralLogoType": "image",
+  "CentralIconClass": "fas fa-route",
+  "CentralLogoImage": "https://www.clipartmax.com/png/middle/357-3574797_clip-art-ai-artificial-computer-deep-learning-intelligence-artificial-intelligence-logo-png.png",
+  "CentralLogoAltText": "Brand logo",
+  "Cards": [
+    {
+      "Eyebrow": "Mission Data Workflows",
+      "Title": "C4ISR",
+      "Description": "Coordinate command, control, communications, computers, intelligence, surveillance, and reconnaissance workflows across operational environments.",
+      "Link": "",
+      "OpenInNewWindow": false
+    },
+    {
+      "Eyebrow": "Mapping and Visualization",
+      "Title": "Geospatial Intelligence",
+      "Description": "Turn location data, imagery, and mission context into map-driven insight for planning, monitoring, and decision support.",
+      "Link": "",
+      "OpenInNewWindow": false
+    },
+    {
+      "Eyebrow": "Network and Cybersecurity Workflows",
+      "Title": "Network Capture and Analysis",
+      "Description": "Capture, inspect, and analyze network traffic to understand operational behavior, detect threats, and validate secure communications.",
+      "Link": "",
+      "OpenInNewWindow": false
+    },
+    {
+      "Eyebrow": "Field-Ready Computing",
+      "Title": "Deployable Compute",
+      "Description": "Bring resilient compute, storage, and analytics capabilities closer to the edge for field teams and disconnected environments.",
+      "Link": "",
+      "OpenInNewWindow": false
+    }
+  ],
+  "OrbitItems": [
+    {
+      "Label": "Mission data workflows",
+      "IconClass": "fas fa-satellite-dish",
+      "IconColor": "orbit-color-blue",
+      "OrbitNumber": "1"
+    },
+    {
+      "Label": "Mapping and visualization",
+      "IconClass": "fas fa-map-location-dot",
+      "IconColor": "orbit-color-green",
+      "OrbitNumber": "1"
+    },
+    {
+      "Label": "Network and cybersecurity workflows",
+      "IconClass": "fas fa-shield-halved",
+      "IconColor": "orbit-color-orange",
+      "OrbitNumber": "2"
+    },
+    {
+      "Label": "Field-ready computing",
+      "IconClass": "fas fa-server",
+      "IconColor": "orbit-color-purple",
+      "OrbitNumber": "2"
+    },
+    {
+      "Label": "Communications",
+      "IconClass": "fas fa-tower-broadcast",
+      "IconColor": "orbit-color-cyan",
+      "OrbitNumber": "2"
+    },
+    {
+      "Label": "Video feeds",
+      "IconClass": "fas fa-video",
+      "IconColor": "orbit-color-rose",
+      "OrbitNumber": "3"
+    },
+    {
+      "Label": "Sensor information",
+      "IconClass": "fas fa-wave-square",
+      "IconColor": "orbit-color-slate",
+      "OrbitNumber": "3"
+    },
+    {
+      "Label": "Dashboards",
+      "IconClass": "fas fa-chart-line",
+      "IconColor": "orbit-color-blue",
+      "OrbitNumber": "3"
+    },
+    {
+      "Label": "AI analytics",
+      "IconClass": "fas fa-brain",
+      "IconColor": "orbit-color-purple",
+      "OrbitNumber": "3"
+    },
+    {
+      "Label": "Cyber monitoring",
+      "IconClass": "fas fa-network-wired",
+      "IconColor": "orbit-color-dark",
+      "OrbitNumber": "3"
+    }
+  ]
+}

--- a/Upendo-Related-Evaluation-Paths-Orbit/options.json
+++ b/Upendo-Related-Evaluation-Paths-Orbit/options.json
@@ -1,0 +1,149 @@
+{
+  "fields": {
+    "ModuleTitle": {
+      "type": "text",
+      "helper": "Administrator-facing title for this module. This syncs with DNN module settings and does not display to visitors.",
+      "placeholder": "Related Evaluation Paths Orbit"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Used to create #anchor-links on the page. Letters, numbers, and hyphens only.",
+      "placeholder": "related-evaluation-paths",
+      "showMessages": false
+    },
+    "SectionEyebrow": {
+      "type": "text",
+      "helper": "Optional. Small label shown above the section heading.",
+      "placeholder": "Related paths"
+    },
+    "SectionHeading": {
+      "type": "text",
+      "helper": "Required. Centered heading shown above the cards. HTML is allowed.",
+      "placeholder": "Related evaluation paths"
+    },
+    "IntroText": {
+      "type": "textarea",
+      "helper": "Optional. Supporting copy shown below the heading. HTML is allowed.",
+      "placeholder": "Explore adjacent evaluation paths that connect mission data, geospatial workflows, network analysis, and deployable compute."
+    },
+    "CentralLogoType": {
+      "type": "select",
+      "helper": "Choose whether the center of the orbit renders a Font Awesome icon or an uploaded image.",
+      "optionLabels": [
+        "Icon",
+        "Image"
+      ],
+      "removeDefaultNone": true
+    },
+    "CentralIconClass": {
+      "type": "text",
+      "helper": "Font Awesome class for the center icon.",
+      "placeholder": "fas fa-route",
+      "dependencies": {
+        "CentralLogoType": [
+          "icon"
+        ]
+      }
+    },
+    "CentralLogoImage": {
+      "type": "image",
+      "uploadfolder": "Content/OpenContent/RelatedEvaluationPathsOrbit/",
+      "typeahead": {
+        "Folder": "Content/OpenContent/RelatedEvaluationPathsOrbit/"
+      },
+      "helper": "Image used in the center when Central Logo Type is Image. For this site, use the Portexa logo image.",
+      "dependencies": {
+        "CentralLogoType": [
+          "image"
+        ]
+      }
+    },
+    "CentralLogoAltText": {
+      "type": "text",
+      "helper": "Accessible alt text for the center image. Falls back to the module or section label when empty.",
+      "placeholder": "Portexa logo",
+      "dependencies": {
+        "CentralLogoType": [
+          "image"
+        ]
+      }
+    },
+    "Cards": {
+      "type": "accordion",
+      "titleField": "Title",
+      "helper": "Add one to four cards. The editor allows up to four cards.",
+      "items": {
+        "fields": {
+          "Eyebrow": {
+            "type": "text",
+            "helper": "Optional. Small category label shown above the card title.",
+            "placeholder": "Mission Data Workflows"
+          },
+          "Title": {
+            "type": "text",
+            "helper": "Required. Card title.",
+            "placeholder": "C4ISR"
+          },
+          "Description": {
+            "type": "textarea",
+            "helper": "Optional. Card body copy. HTML is allowed.",
+            "placeholder": "Coordinate command, control, communications, computers, intelligence, surveillance, and reconnaissance workflows."
+          },
+          "Link": {
+            "type": "text",
+            "helper": "Optional. When set, the full card renders as a clickable link.",
+            "placeholder": "/solutions/command-and-control/c4isr"
+          },
+          "OpenInNewWindow": {
+            "type": "checkbox",
+            "helper": "Open the card link in a new browser tab."
+          }
+        }
+      }
+    },
+    "OrbitItems": {
+      "type": "accordion",
+      "titleField": "Label",
+      "helper": "Add decorative orbit chips. Use existing Font Awesome classes only. Items are positioned automatically by display order within each orbit.",
+      "items": {
+        "fields": {
+          "Label": {
+            "type": "text",
+            "helper": "Required. Internal label and hover title for the decorative chip.",
+            "placeholder": "Mission data workflows"
+          },
+          "IconClass": {
+            "type": "text",
+            "helper": "Optional. Existing Font Awesome class. Falls back to fas fa-circle.",
+            "placeholder": "fas fa-satellite-dish"
+          },
+          "IconColor": {
+            "type": "select",
+            "helper": "Choose the icon color.",
+            "optionLabels": [
+              "Blue",
+              "Cyan",
+              "Green",
+              "Orange",
+              "Purple",
+              "Rose",
+              "Slate",
+              "Dark"
+            ],
+            "removeDefaultNone": true
+          },
+          "OrbitNumber": {
+            "type": "select",
+            "helper": "Choose which dotted orbit ring should contain this item.",
+            "optionLabels": [
+              "Inner Orbit",
+              "Middle Orbit",
+              "Outer Orbit"
+            ],
+            "removeDefaultNone": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/Upendo-Related-Evaluation-Paths-Orbit/schema.json
+++ b/Upendo-Related-Evaluation-Paths-Orbit/schema.json
@@ -1,0 +1,136 @@
+{
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+      "pattern": "^[a-zA-Z0-9\\-]+$"
+    },
+    "SectionEyebrow": {
+      "type": "string",
+      "title": "Section Eyebrow"
+    },
+    "SectionHeading": {
+      "type": "string",
+      "title": "Section Heading"
+    },
+    "IntroText": {
+      "type": "string",
+      "title": "Intro Text"
+    },
+    "CentralLogoType": {
+      "type": "string",
+      "title": "Central Logo Type",
+      "enum": [
+        "icon",
+        "image"
+      ]
+    },
+    "CentralIconClass": {
+      "type": "string",
+      "title": "Central Icon Class",
+      "dependencies": [
+        "CentralLogoType"
+      ]
+    },
+    "CentralLogoImage": {
+      "type": "string",
+      "title": "Central Logo Image",
+      "dependencies": [
+        "CentralLogoType"
+      ]
+    },
+    "CentralLogoAltText": {
+      "type": "string",
+      "title": "Central Logo Alt Text",
+      "dependencies": [
+        "CentralLogoType"
+      ]
+    },
+    "Cards": {
+      "type": "array",
+      "title": "Cards",
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "properties": {
+          "Eyebrow": {
+            "type": "string",
+            "title": "Eyebrow"
+          },
+          "Title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "Link": {
+            "type": "string",
+            "title": "Link"
+          },
+          "OpenInNewWindow": {
+            "type": "boolean",
+            "title": "Open In New Window"
+          }
+        },
+        "required": [
+          "Title"
+        ]
+      }
+    },
+    "OrbitItems": {
+      "type": "array",
+      "title": "Orbit Items",
+      "items": {
+        "type": "object",
+        "properties": {
+          "Label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "IconClass": {
+            "type": "string",
+            "title": "Icon Class"
+          },
+          "IconColor": {
+            "type": "string",
+            "title": "Icon Color",
+            "enum": [
+              "orbit-color-blue",
+              "orbit-color-cyan",
+              "orbit-color-green",
+              "orbit-color-orange",
+              "orbit-color-purple",
+              "orbit-color-rose",
+              "orbit-color-slate",
+              "orbit-color-dark"
+            ]
+          },
+          "OrbitNumber": {
+            "type": "string",
+            "title": "Orbit Number",
+            "enum": [
+              "1",
+              "2",
+              "3"
+            ]
+          }
+        },
+        "required": [
+          "Label",
+          "OrbitNumber"
+        ]
+      }
+    }
+  },
+  "required": [
+    "SectionHeading",
+    "Cards"
+  ]
+}

--- a/Upendo-Related-Evaluation-Paths-Orbit/template-data.json
+++ b/Upendo-Related-Evaluation-Paths-Orbit/template-data.json
@@ -1,0 +1,11 @@
+{
+  "BackgroundColorClass": "",
+  "ContainerClass": "container-xxl",
+  "AnimationSpeed": "orbit-speed-normal",
+  "OrbitVisibility": "orbit-visible",
+  "OrbitOpacity": "1",
+  "MarginTop": "mt-auto",
+  "MarginBottom": "mb-auto",
+  "PaddingTop": "pt-5",
+  "PaddingBottom": "pb-5"
+}

--- a/Upendo-Related-Evaluation-Paths-Orbit/template-options.json
+++ b/Upendo-Related-Evaluation-Paths-Orbit/template-options.json
@@ -1,0 +1,143 @@
+{
+  "fields": {
+    "BackgroundColorClass": {
+      "type": "select",
+      "helper": "Choose a built-in Bootstrap background color class or a custom theme background color for this section.",
+      "optionLabels": [
+        "None / Theme Default",
+        "Primary",
+        "Primary (theme)",
+        "Secondary",
+        "Secondary (theme)",
+        "Tertiary (theme)",
+        "Quaternary (theme)",
+        "H5 (theme)",
+        "H6 (theme)",
+        "Success",
+        "Danger",
+        "Warning",
+        "Info",
+        "Light",
+        "Dark",
+        "White",
+        "Body",
+        "Transparent",
+        "Primary Subtle",
+        "Secondary Subtle",
+        "Success Subtle",
+        "Danger Subtle",
+        "Warning Subtle",
+        "Info Subtle",
+        "Light Subtle",
+        "Dark Subtle",
+        "Off White",
+        "Warm White",
+        "Cream",
+        "Soft Beige",
+        "Sand",
+        "Light Sage",
+        "Sage",
+        "Pale Green",
+        "Mist",
+        "Soft Gray",
+        "Forest Green"
+      ],
+      "sort": true,
+      "removeDefaultNone": true
+    },
+    "ContainerClass": {
+      "type": "text",
+      "helper": "Wrapper class for the content width. Use Bootstrap container classes or a theme-specific container class.",
+      "placeholder": "container-xxl"
+    },
+    "AnimationSpeed": {
+      "type": "select",
+      "helper": "Choose the orbit animation speed.",
+      "optionLabels": [
+        "Slow",
+        "Normal",
+        "Fast"
+      ],
+      "removeDefaultNone": true
+    },
+    "OrbitVisibility": {
+      "type": "select",
+      "helper": "Show or hide the decorative orbit.",
+      "optionLabels": [
+        "Visible",
+        "Hidden"
+      ],
+      "removeDefaultNone": true
+    },
+    "OrbitOpacity": {
+      "type": "select",
+      "helper": "Control the decorative orbit opacity.",
+      "optionLabels": [
+        "100%",
+        "85%",
+        "70%",
+        "55%",
+        "40%",
+        "25%",
+        "10%"
+      ],
+      "removeDefaultNone": true
+    },
+    "MarginTop": {
+      "title": "Margin (top)",
+      "type": "select",
+      "optionLabels": [
+        "mt-0",
+        "mt-1",
+        "mt-2",
+        "mt-3",
+        "mt-4",
+        "mt-5",
+        "mt-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "MarginBottom": {
+      "title": "Margin (bottom)",
+      "type": "select",
+      "optionLabels": [
+        "mb-0",
+        "mb-1",
+        "mb-2",
+        "mb-3",
+        "mb-4",
+        "mb-5",
+        "mb-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "PaddingTop": {
+      "title": "Padding (top)",
+      "type": "select",
+      "optionLabels": [
+        "pt-0",
+        "pt-1",
+        "pt-2",
+        "pt-3",
+        "pt-4",
+        "pt-5",
+        "pt-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "PaddingBottom": {
+      "title": "Padding (bottom)",
+      "type": "select",
+      "optionLabels": [
+        "pb-0",
+        "pb-1",
+        "pb-2",
+        "pb-3",
+        "pb-4",
+        "pb-5",
+        "pb-auto"
+      ],
+      "removeDefaultNone": true
+    }
+  }
+}

--- a/Upendo-Related-Evaluation-Paths-Orbit/template-schema.json
+++ b/Upendo-Related-Evaluation-Paths-Orbit/template-schema.json
@@ -1,0 +1,134 @@
+{
+  "type": "object",
+  "properties": {
+    "BackgroundColorClass": {
+      "type": "string",
+      "title": "Background Color",
+      "enum": [
+        "",
+        "bg-primary",
+        "bg-primary-scoped",
+        "bg-secondary",
+        "bg-secondary-scoped",
+        "bg-tertiary",
+        "bg-quaternary",
+        "bg-h5",
+        "bg-h6",
+        "bg-success",
+        "bg-danger",
+        "bg-warning",
+        "bg-info",
+        "bg-light",
+        "bg-dark",
+        "bg-white",
+        "bg-body",
+        "bg-transparent",
+        "bg-primary-subtle",
+        "bg-secondary-subtle",
+        "bg-success-subtle",
+        "bg-danger-subtle",
+        "bg-warning-subtle",
+        "bg-info-subtle",
+        "bg-light-subtle",
+        "bg-dark-subtle",
+        "bg-off-white",
+        "bg-warm-white",
+        "bg-cream",
+        "bg-soft-beige",
+        "bg-sand",
+        "bg-light-sage",
+        "bg-sage",
+        "bg-pale-green",
+        "bg-mist",
+        "bg-soft-gray",
+        "bg-forest-green"
+      ]
+    },
+    "ContainerClass": {
+      "type": "string",
+      "title": "Container Class"
+    },
+    "AnimationSpeed": {
+      "type": "string",
+      "title": "Animation Speed",
+      "enum": [
+        "orbit-speed-slow",
+        "orbit-speed-normal",
+        "orbit-speed-fast"
+      ]
+    },
+    "OrbitVisibility": {
+      "type": "string",
+      "title": "Orbit Visibility",
+      "enum": [
+        "orbit-visible",
+        "orbit-hidden"
+      ]
+    },
+    "OrbitOpacity": {
+      "type": "string",
+      "title": "Orbit Opacity",
+      "enum": [
+        "1",
+        "0.85",
+        "0.7",
+        "0.55",
+        "0.4",
+        "0.25",
+        "0.1"
+      ]
+    },
+    "MarginTop": {
+      "title": "Margin (top)",
+      "type": "string",
+      "enum": [
+        "mt-0",
+        "mt-1",
+        "mt-2",
+        "mt-3",
+        "mt-4",
+        "mt-5",
+        "mt-auto"
+      ]
+    },
+    "MarginBottom": {
+      "title": "Margin (bottom)",
+      "type": "string",
+      "enum": [
+        "mb-0",
+        "mb-1",
+        "mb-2",
+        "mb-3",
+        "mb-4",
+        "mb-5",
+        "mb-auto"
+      ]
+    },
+    "PaddingTop": {
+      "title": "Padding (top)",
+      "type": "string",
+      "enum": [
+        "pt-0",
+        "pt-1",
+        "pt-2",
+        "pt-3",
+        "pt-4",
+        "pt-5",
+        "pt-auto"
+      ]
+    },
+    "PaddingBottom": {
+      "title": "Padding (bottom)",
+      "type": "string",
+      "enum": [
+        "pb-0",
+        "pb-1",
+        "pb-2",
+        "pb-3",
+        "pb-4",
+        "pb-5",
+        "pb-auto"
+      ]
+    }
+  }
+}

--- a/Upendo-Related-Evaluation-Paths-Orbit/template.cshtml
+++ b/Upendo-Related-Evaluation-Paths-Orbit/template.cshtml
@@ -1,0 +1,430 @@
+@using System
+@using System.Collections.Generic
+@using Upendo.Libraries.RunsOnUpendoCore.Helpers
+@inherits Satrabel.OpenContent.Components.OpenContentWebPage
+
+@functions {
+    private static dynamic GetDynamicValue(dynamic source, string propertyName)
+    {
+        if (source == null || string.IsNullOrWhiteSpace(propertyName))
+        {
+            return null;
+        }
+
+        try
+        {
+            var dictionary = source as IDictionary<string, object>;
+            if (dictionary != null && dictionary.ContainsKey(propertyName))
+            {
+                return dictionary[propertyName];
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            return source[propertyName];
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            var property = source.GetType().GetProperty(propertyName);
+            return property != null ? property.GetValue(source, null) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string GetDynamicString(dynamic source, string propertyName)
+    {
+        var value = GetDynamicValue(source, propertyName);
+        return value != null ? Convert.ToString(value) : string.Empty;
+    }
+
+    private static string GetImageUrl(dynamic image)
+    {
+        if (image == null)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var dictionary = image as IDictionary<string, object>;
+            if (dictionary != null && dictionary.ContainsKey("Url") && dictionary["Url"] != null)
+            {
+                return Convert.ToString(dictionary["Url"]);
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            if (image.Url != null)
+            {
+                return Convert.ToString(image.Url);
+            }
+        }
+        catch
+        {
+        }
+
+        return image is string ? Convert.ToString(image) : string.Empty;
+    }
+
+    private static bool GetBoolean(dynamic value)
+    {
+        if (value == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return Convert.ToBoolean(value);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string GetLinkUrl(dynamic link)
+    {
+        if (link == null)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            if (link.Url != null)
+            {
+                return Convert.ToString(link.Url);
+            }
+        }
+        catch
+        {
+        }
+
+        return Convert.ToString(link);
+    }
+
+    private static int GetOrbitNumber(dynamic value)
+    {
+        if (value == null)
+        {
+            return 1;
+        }
+
+        try
+        {
+            var orbitNumber = Convert.ToInt32(value);
+            if (orbitNumber < 1 || orbitNumber > 3)
+            {
+                return 1;
+            }
+
+            return orbitNumber;
+        }
+        catch
+        {
+            return 1;
+        }
+    }
+
+    private static string GetOrbitOpacity(dynamic value)
+    {
+        string opacity = value != null ? Convert.ToString(value) : string.Empty;
+        switch (opacity)
+        {
+            case "1":
+            case "0.85":
+            case "0.7":
+            case "0.55":
+            case "0.4":
+            case "0.25":
+            case "0.1":
+                return opacity;
+            default:
+                return "1";
+        }
+    }
+}
+
+@{
+    TemplateHelper.HideAdminBorder(Model.Context.ModuleId, Model.Context.TabId);
+    RegisterStyleSheet("template.css");
+
+    var moduleTitle = Model.ModuleTitle != null ? Convert.ToString(Model.ModuleTitle) : string.Empty;
+    var moduleAnchor = Model.ModuleAnchor != null ? Convert.ToString(Model.ModuleAnchor) : string.Empty;
+    var sectionEyebrow = GetDynamicString(Model, "SectionEyebrow");
+    var sectionHeading = Model.SectionHeading != null ? Convert.ToString(Model.SectionHeading) : string.Empty;
+    var introText = Model.IntroText != null ? Convert.ToString(Model.IntroText) : string.Empty;
+    var centralLogoType = GetDynamicString(Model, "CentralLogoType");
+    var centralIconClass = GetDynamicString(Model, "CentralIconClass");
+    var centralLogoImageUrl = GetImageUrl(GetDynamicValue(Model, "CentralLogoImage"));
+    var centralLogoAltText = GetDynamicString(Model, "CentralLogoAltText");
+
+    var backgroundColorClass = Model.Settings != null && Model.Settings.BackgroundColorClass != null
+        ? Convert.ToString(Model.Settings.BackgroundColorClass)
+        : string.Empty;
+
+    var containerClass = Model.Settings != null && Model.Settings.ContainerClass != null
+        ? Convert.ToString(Model.Settings.ContainerClass)
+        : "container-xxl";
+
+    var animationSpeed = Model.Settings != null && Model.Settings.AnimationSpeed != null
+        ? Convert.ToString(Model.Settings.AnimationSpeed)
+        : "orbit-speed-normal";
+
+    var orbitVisibility = Model.Settings != null && Model.Settings.OrbitVisibility != null
+        ? Convert.ToString(Model.Settings.OrbitVisibility)
+        : "orbit-visible";
+
+    var orbitOpacity = GetOrbitOpacity(GetDynamicValue(Model.Settings, "OrbitOpacity"));
+
+    var marginTop = Model.Settings != null && Model.Settings.MarginTop != null
+        ? Convert.ToString(Model.Settings.MarginTop)
+        : string.Empty;
+
+    var marginBottom = Model.Settings != null && Model.Settings.MarginBottom != null
+        ? Convert.ToString(Model.Settings.MarginBottom)
+        : string.Empty;
+
+    var paddingTop = Model.Settings != null && Model.Settings.PaddingTop != null
+        ? Convert.ToString(Model.Settings.PaddingTop)
+        : string.Empty;
+
+    var paddingBottom = Model.Settings != null && Model.Settings.PaddingBottom != null
+        ? Convert.ToString(Model.Settings.PaddingBottom)
+        : string.Empty;
+
+    if (string.IsNullOrWhiteSpace(containerClass))
+    {
+        containerClass = "container-xxl";
+    }
+
+    if (!string.Equals(centralLogoType, "image", StringComparison.OrdinalIgnoreCase))
+    {
+        centralLogoType = "icon";
+    }
+
+    if (string.IsNullOrWhiteSpace(centralIconClass))
+    {
+        centralIconClass = "fas fa-route";
+    }
+
+    if (string.IsNullOrWhiteSpace(animationSpeed))
+    {
+        animationSpeed = "orbit-speed-normal";
+    }
+
+    if (string.IsNullOrWhiteSpace(orbitVisibility))
+    {
+        orbitVisibility = "orbit-visible";
+    }
+
+    var cards = new List<dynamic>();
+    if (Model.Cards != null)
+    {
+        foreach (var card in Model.Cards)
+        {
+            var eyebrow = GetDynamicString(card, "Eyebrow");
+            var title = GetDynamicString(card, "Title");
+            var description = GetDynamicString(card, "Description");
+
+            if (string.IsNullOrWhiteSpace(eyebrow) && string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(description))
+            {
+                continue;
+            }
+
+            cards.Add(card);
+            if (cards.Count >= 4)
+            {
+                break;
+            }
+        }
+    }
+
+    var orbitItems = new List<dynamic>();
+    if (Model.OrbitItems != null)
+    {
+        foreach (var item in Model.OrbitItems)
+        {
+            orbitItems.Add(item);
+        }
+    }
+
+    var sectionClass = "upendo-related-evaluation-orbit " + animationSpeed + " " + orbitVisibility;
+    if (!string.IsNullOrWhiteSpace(backgroundColorClass)) { sectionClass += " " + backgroundColorClass; }
+    if (!string.IsNullOrWhiteSpace(marginTop)) { sectionClass += " " + marginTop; }
+    if (!string.IsNullOrWhiteSpace(marginBottom)) { sectionClass += " " + marginBottom; }
+    if (!string.IsNullOrWhiteSpace(paddingTop)) { sectionClass += " " + paddingTop; }
+    if (!string.IsNullOrWhiteSpace(paddingBottom)) { sectionClass += " " + paddingBottom; }
+
+    var generatedModuleAnchor = "upendo-related-evaluation-orbit-" + Model.Context.ModuleId;
+    var sectionId = !string.IsNullOrWhiteSpace(moduleAnchor) ? moduleAnchor : generatedModuleAnchor;
+    var headingId = generatedModuleAnchor + "-heading";
+    var ariaLabel = !string.IsNullOrWhiteSpace(moduleTitle)
+        ? moduleTitle
+        : (!string.IsNullOrWhiteSpace(sectionHeading) ? sectionHeading : "Related evaluation paths");
+    var useCentralLogoImage = string.Equals(centralLogoType, "image", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(centralLogoImageUrl);
+    var centralLogoImageAlt = !string.IsNullOrWhiteSpace(centralLogoAltText) ? centralLogoAltText : ariaLabel;
+
+    var hasText = !string.IsNullOrWhiteSpace(sectionEyebrow) || !string.IsNullOrWhiteSpace(sectionHeading) || !string.IsNullOrWhiteSpace(introText);
+    var hasRenderableContent = hasText || cards.Count > 0 || orbitItems.Count > 0;
+    var sectionStyle = "--related-orbit-opacity:" + orbitOpacity + ";";
+    var cardsClass = "upendo-related-evaluation-orbit__cards upendo-related-evaluation-orbit__cards--count-" + cards.Count;
+}
+
+@if (hasRenderableContent)
+{
+    <section class="@sectionClass" id="@sectionId" aria-label="@ariaLabel" style="@sectionStyle">
+        <div class="@containerClass upendo-related-evaluation-orbit__container">
+            @if (hasText)
+            {
+                <header class="upendo-related-evaluation-orbit__header">
+                    @if (!string.IsNullOrWhiteSpace(sectionEyebrow))
+                    {
+                        <div class="upendo-related-evaluation-orbit__section-eyebrow">@Html.Raw(sectionEyebrow)</div>
+                    }
+
+                    @if (!string.IsNullOrWhiteSpace(sectionHeading))
+                    {
+                        <h2 id="@headingId" class="upendo-related-evaluation-orbit__heading text-notransform">@Html.Raw(sectionHeading)</h2>
+                    }
+
+                    @if (!string.IsNullOrWhiteSpace(introText))
+                    {
+                        <div class="upendo-related-evaluation-orbit__intro">@Html.Raw(introText)</div>
+                    }
+                </header>
+            }
+
+            <div class="upendo-related-evaluation-orbit__layout">
+                @if (cards.Count > 0)
+                {
+                    <div class="@cardsClass">
+                        @foreach (var card in cards)
+                        {
+                            var eyebrow = GetDynamicString(card, "Eyebrow");
+                            var title = GetDynamicString(card, "Title");
+                            var description = GetDynamicString(card, "Description");
+                            var link = GetLinkUrl(GetDynamicValue(card, "Link"));
+                            var openInNewWindow = GetBoolean(GetDynamicValue(card, "OpenInNewWindow"));
+                            var hasLink = !string.IsNullOrWhiteSpace(link);
+
+                            if (hasLink)
+                            {
+                                if (openInNewWindow)
+                                {
+                                    <a class="upendo-related-evaluation-orbit__card" href="@link" target="_blank" rel="noopener noreferrer">
+                                        @RenderCardContent(eyebrow, title, description)
+                                    </a>
+                                }
+                                else
+                                {
+                                    <a class="upendo-related-evaluation-orbit__card" href="@link">
+                                        @RenderCardContent(eyebrow, title, description)
+                                    </a>
+                                }
+                            }
+                            else
+                            {
+                                <article class="upendo-related-evaluation-orbit__card">
+                                    @RenderCardContent(eyebrow, title, description)
+                                </article>
+                            }
+                        }
+                    </div>
+                }
+
+                @if (orbitItems.Count > 0)
+                {
+                    <div class="upendo-related-evaluation-orbit__visual" aria-hidden="@(useCentralLogoImage ? "false" : "true")">
+                        <div class="upendo-related-evaluation-orbit__orbit-stage">
+                            @for (var orbitNumber = 1; orbitNumber <= 3; orbitNumber++)
+                            {
+                                var orbitClass = "upendo-related-evaluation-orbit__orbit upendo-related-evaluation-orbit__orbit--" + orbitNumber;
+                                var positionIndex = 0;
+
+                                <div class="@orbitClass" aria-hidden="true">
+                                    @foreach (var item in orbitItems)
+                                    {
+                                        var itemOrbitNumber = GetOrbitNumber(GetDynamicValue(item, "OrbitNumber"));
+                                        if (itemOrbitNumber != orbitNumber)
+                                        {
+                                            continue;
+                                        }
+
+                                        var label = GetDynamicString(item, "Label");
+                                        var iconClass = GetDynamicString(item, "IconClass");
+                                        var iconColor = GetDynamicString(item, "IconColor");
+                                        if (string.IsNullOrWhiteSpace(iconClass))
+                                        {
+                                            iconClass = "fas fa-circle";
+                                        }
+
+                                        if (string.IsNullOrWhiteSpace(iconColor))
+                                        {
+                                            iconColor = "orbit-color-slate";
+                                        }
+
+                                        var itemPositionClass = "upendo-related-evaluation-orbit__item--pos-" + (positionIndex % 8);
+                                        var itemClass = "upendo-related-evaluation-orbit__item " + itemPositionClass + " " + iconColor;
+                                        positionIndex++;
+
+                                        <span class="@itemClass" title="@label">
+                                            <i class="@iconClass"></i>
+                                        </span>
+                                    }
+                                </div>
+                            }
+
+                            <div class="upendo-related-evaluation-orbit__center">
+                                @if (useCentralLogoImage)
+                                {
+                                    <img class="upendo-related-evaluation-orbit__center-image" src="@centralLogoImageUrl" alt="@centralLogoImageAlt" loading="lazy" decoding="async" />
+                                }
+                                else
+                                {
+                                    <i class="@centralIconClass" aria-hidden="true"></i>
+                                }
+                            </div>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+    </section>
+}
+
+@helper RenderCardContent(string eyebrow, string title, string description)
+{
+    <span class="upendo-related-evaluation-orbit__card-inner">
+        @if (!string.IsNullOrWhiteSpace(eyebrow))
+        {
+            <span class="upendo-related-evaluation-orbit__eyebrow">@Html.Raw(eyebrow)</span>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(title))
+        {
+            <span class="upendo-related-evaluation-orbit__title">@Html.Raw(title)</span>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(description))
+        {
+            <span class="upendo-related-evaluation-orbit__description">@Html.Raw(description)</span>
+        }
+    </span>
+}

--- a/Upendo-Related-Evaluation-Paths-Orbit/template.css
+++ b/Upendo-Related-Evaluation-Paths-Orbit/template.css
@@ -1,0 +1,362 @@
+.upendo-related-evaluation-orbit {
+  --related-orbit-text: #111827;
+  --related-orbit-muted: #647084;
+  --related-orbit-line: rgba(18, 26, 44, 0.13);
+  --related-orbit-card: rgba(255, 255, 255, 0.95);
+  --related-orbit-accent: #2563eb;
+  --related-orbit-radius-1: 7.6rem;
+  --related-orbit-radius-2: 11.1rem;
+  --related-orbit-radius-3: 14.6rem;
+  position: relative;
+  overflow: hidden;
+  color: inherit;
+}
+
+.upendo-related-evaluation-orbit * {
+  box-sizing: border-box;
+}
+
+.upendo-related-evaluation-orbit.bg-soft-gray {
+  background-color: #ebeef3 !important;
+}
+
+.upendo-related-evaluation-orbit__container {
+  position: relative;
+  z-index: 2;
+}
+
+.upendo-related-evaluation-orbit__header {
+  max-width: 52rem;
+  margin: 0 auto 3rem auto;
+  text-align: center;
+}
+
+.upendo-related-evaluation-orbit__heading {
+  margin: 0;
+  color: inherit;
+  line-height: 1.2;
+}
+
+.upendo-related-evaluation-orbit__section-eyebrow {
+  margin: 0 0 0.75rem;
+  color: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  opacity: 0.82;
+}
+
+.upendo-related-evaluation-orbit__intro {
+  max-width: 44rem;
+  margin: 1rem auto 0;
+  color: var(--related-orbit-muted);
+  font-size: clamp(1rem, 1.25vw, 1.14rem);
+  line-height: 1.7;
+}
+
+.upendo-related-evaluation-orbit__intro p:last-child {
+  margin-bottom: 0;
+}
+
+.upendo-related-evaluation-orbit__layout {
+  position: relative;
+  min-height: 19rem;
+}
+
+.upendo-related-evaluation-orbit__cards {
+  position: relative;
+  z-index: 3;
+  display: grid;
+  align-items: stretch;
+  justify-items: stretch;
+  gap: 1.5rem;
+  width: min(100%, 1320px);
+  margin: 0 auto;
+}
+
+.upendo-related-evaluation-orbit__cards--count-1 {
+  grid-template-columns: minmax(0, 24rem);
+  justify-content: center;
+}
+
+.upendo-related-evaluation-orbit__cards--count-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-width: 45rem;
+}
+
+.upendo-related-evaluation-orbit__cards--count-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  max-width: 68rem;
+}
+
+.upendo-related-evaluation-orbit__cards--count-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.upendo-related-evaluation-orbit__card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 12rem;
+  margin-top: 0;
+  overflow: hidden;
+  border: 1px solid var(--related-orbit-line);
+  border-radius: 1.75rem;
+  background-color: #ffffff;
+  color: inherit;
+  text-align: center;
+  text-decoration: none;
+  box-shadow: 0 0.5rem 1.25rem rgba(0, 0, 0, 0.06);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
+}
+
+.upendo-related-evaluation-orbit a.upendo-related-evaluation-orbit__card:hover,
+.upendo-related-evaluation-orbit a.upendo-related-evaluation-orbit__card:focus {
+  border-color: rgba(0, 0, 0, 0.08);
+  color: inherit;
+  background-color: var(--bs-secondary-bg, #f8f6ef);
+  text-decoration: none;
+  box-shadow: 0 0.85rem 1.8rem rgba(0, 0, 0, 0.08);
+  transform: translateY(-0.25rem);
+}
+
+.upendo-related-evaluation-orbit__card-inner {
+  display: grid;
+  grid-template-rows: 2.5rem 3.9rem 1fr;
+  row-gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 2rem 1.5rem;
+}
+
+.upendo-related-evaluation-orbit__eyebrow {
+  display: block;
+  align-self: start;
+  min-height: 0;
+  margin: 0;
+  color: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  opacity: 0.9;
+}
+
+.upendo-related-evaluation-orbit__title {
+  display: block;
+  align-self: center;
+  margin: 0;
+  color: inherit;
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.upendo-related-evaluation-orbit__description {
+  display: block;
+  align-self: start;
+  margin: 0;
+  color: inherit;
+  font-size: 0.975rem;
+  line-height: 1.5;
+  opacity: 0.78;
+}
+
+.upendo-related-evaluation-orbit__visual {
+  position: absolute;
+  top: 50%;
+  right: clamp(-34rem, -28vw, -23rem);
+  z-index: 0;
+  width: 39rem;
+  height: 39rem;
+  opacity: var(--related-orbit-opacity, 1);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.upendo-related-evaluation-orbit.orbit-hidden .upendo-related-evaluation-orbit__visual {
+  display: none;
+}
+
+.upendo-related-evaluation-orbit__orbit-stage {
+  position: absolute;
+  inset: 0;
+}
+
+.upendo-related-evaluation-orbit__orbit-stage::before {
+  position: absolute;
+  inset: 11.5rem;
+  content: "";
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.1), rgba(37, 99, 235, 0));
+  filter: blur(0.15rem);
+}
+
+.upendo-related-evaluation-orbit__orbit {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border: 2px dotted rgba(71, 85, 105, 0.18);
+  border-radius: 50%;
+  animation-name: upendoRelatedEvaluationOrbitSpin;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+.upendo-related-evaluation-orbit__orbit--1 {
+  width: calc(var(--related-orbit-radius-1) * 2);
+  height: calc(var(--related-orbit-radius-1) * 2);
+  animation-duration: 24s;
+}
+
+.upendo-related-evaluation-orbit__orbit--2 {
+  width: calc(var(--related-orbit-radius-2) * 2);
+  height: calc(var(--related-orbit-radius-2) * 2);
+  animation-duration: 34s;
+  animation-direction: reverse;
+}
+
+.upendo-related-evaluation-orbit__orbit--3 {
+  width: calc(var(--related-orbit-radius-3) * 2);
+  height: calc(var(--related-orbit-radius-3) * 2);
+  animation-duration: 46s;
+}
+
+.upendo-related-evaluation-orbit.orbit-speed-slow .upendo-related-evaluation-orbit__orbit--1 { animation-duration: 36s; }
+.upendo-related-evaluation-orbit.orbit-speed-slow .upendo-related-evaluation-orbit__orbit--2 { animation-duration: 52s; }
+.upendo-related-evaluation-orbit.orbit-speed-slow .upendo-related-evaluation-orbit__orbit--3 { animation-duration: 68s; }
+.upendo-related-evaluation-orbit.orbit-speed-fast .upendo-related-evaluation-orbit__orbit--1 { animation-duration: 15s; }
+.upendo-related-evaluation-orbit.orbit-speed-fast .upendo-related-evaluation-orbit__orbit--2 { animation-duration: 23s; }
+.upendo-related-evaluation-orbit.orbit-speed-fast .upendo-related-evaluation-orbit__orbit--3 { animation-duration: 31s; }
+
+.upendo-related-evaluation-orbit__orbit--1 .upendo-related-evaluation-orbit__item { --related-orbit-radius: var(--related-orbit-radius-1); }
+.upendo-related-evaluation-orbit__orbit--2 .upendo-related-evaluation-orbit__item { --related-orbit-radius: var(--related-orbit-radius-2); }
+.upendo-related-evaluation-orbit__orbit--3 .upendo-related-evaluation-orbit__item { --related-orbit-radius: var(--related-orbit-radius-3); }
+
+.upendo-related-evaluation-orbit__item {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.35rem;
+  height: 3.35rem;
+  margin: -1.675rem 0 0 -1.675rem;
+  border: 1px solid rgba(15, 23, 42, 0.09);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.78);
+  color: #334155;
+  font-size: 1.28rem;
+  box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.08);
+}
+
+.upendo-related-evaluation-orbit__item--pos-0 { transform: rotate(0deg) translateX(var(--related-orbit-radius)) rotate(0deg); }
+.upendo-related-evaluation-orbit__item--pos-1 { transform: rotate(45deg) translateX(var(--related-orbit-radius)) rotate(-45deg); }
+.upendo-related-evaluation-orbit__item--pos-2 { transform: rotate(90deg) translateX(var(--related-orbit-radius)) rotate(-90deg); }
+.upendo-related-evaluation-orbit__item--pos-3 { transform: rotate(135deg) translateX(var(--related-orbit-radius)) rotate(-135deg); }
+.upendo-related-evaluation-orbit__item--pos-4 { transform: rotate(180deg) translateX(var(--related-orbit-radius)) rotate(-180deg); }
+.upendo-related-evaluation-orbit__item--pos-5 { transform: rotate(225deg) translateX(var(--related-orbit-radius)) rotate(-225deg); }
+.upendo-related-evaluation-orbit__item--pos-6 { transform: rotate(270deg) translateX(var(--related-orbit-radius)) rotate(-270deg); }
+.upendo-related-evaluation-orbit__item--pos-7 { transform: rotate(315deg) translateX(var(--related-orbit-radius)) rotate(-315deg); }
+.upendo-related-evaluation-orbit__center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 5.6rem;
+  height: 5.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  border-radius: 1.45rem;
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--related-orbit-accent);
+  font-size: 2.35rem;
+  box-shadow: 0 1.25rem 3rem rgba(15, 23, 42, 0.1);
+  transform: translate(-50%, -50%);
+}
+
+.upendo-related-evaluation-orbit__center-image {
+  display: block;
+  max-width: 72%;
+  max-height: 72%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+}
+
+.upendo-related-evaluation-orbit .orbit-color-blue { color: #2563eb; }
+.upendo-related-evaluation-orbit .orbit-color-cyan { color: #0891b2; }
+.upendo-related-evaluation-orbit .orbit-color-green { color: #16a34a; }
+.upendo-related-evaluation-orbit .orbit-color-orange { color: #ea580c; }
+.upendo-related-evaluation-orbit .orbit-color-purple { color: #7c3aed; }
+.upendo-related-evaluation-orbit .orbit-color-rose { color: #e11d48; }
+.upendo-related-evaluation-orbit .orbit-color-slate { color: #475569; }
+.upendo-related-evaluation-orbit .orbit-color-dark { color: #111827; }
+
+@keyframes upendoRelatedEvaluationOrbitSpin {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+@media (max-width: 1199.98px) {
+  .upendo-related-evaluation-orbit__cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    max-width: 45rem;
+  }
+
+  .upendo-related-evaluation-orbit__cards--count-1 {
+    grid-template-columns: minmax(0, 24rem);
+  }
+
+  .upendo-related-evaluation-orbit__visual {
+    right: -25rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .upendo-related-evaluation-orbit__cards {
+    grid-template-columns: 1fr;
+    max-width: 28rem;
+  }
+
+  .upendo-related-evaluation-orbit__card {
+    min-height: 0;
+  }
+
+  .upendo-related-evaluation-orbit__eyebrow {
+    min-height: 0;
+    margin-bottom: 0.85rem;
+  }
+
+  .upendo-related-evaluation-orbit__title {
+    font-size: 1.3rem;
+  }
+
+  .upendo-related-evaluation-orbit__visual {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .upendo-related-evaluation-orbit__orbit {
+    animation: none;
+  }
+
+  .upendo-related-evaluation-orbit__card {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Adds the Upendo Related Evaluation Paths Orbit OpenContent template with sample content, editor schema/options, template settings, Razor markup, and responsive orbit styling.

<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #

## Description
<!--- Describe your changes in detail -->
Adds the Upendo Related Evaluation Paths Orbit OpenContent template.

Includes:
- Sample data for related evaluation path cards and orbit items
- Editor schema and options
- Template settings schema and options
- Razor markup for cards, central logo/icon, and decorative orbit items
- Responsive CSS with reduced-motion support
- Automatic orbit item positioning by display order


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Reviewed the working tree and validated JSON syntax for the new template files.

Compared the file structure against nearby Upendo templates using the same OpenContent template pattern.

## Screenshots (if appropriate):
<img width="1807" height="556" alt="image" src="https://github.com/user-attachments/assets/6739d68b-84e3-42e3-9b86-5fe8ea9a067f" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.