### PR TITLE
Add Parallax Value Props List Columns Template

### DIFF
--- a/Upendo-Value-Props-List-Columns-Parallax/data.json
+++ b/Upendo-Value-Props-List-Columns-Parallax/data.json
@@ -1,0 +1,30 @@
+{
+  "ModuleTitle": "Upendo-Value-Props-List-Columns-Parallax",
+  "ModuleAnchor": "",
+  "SectionHeading": "Practices for Modern Vitality",
+  "IntroText": "Science-backed practices that support clarity, connection, and restoration.",
+  "BackgroundImage": "https://images.unsplash.com/photo-1709676320911-7fee44490743?auto=format&fit=crop&w=1600&q=80",
+  "ListIcon": "fas fa-check",
+  "ValueProps": [
+    {
+      "Title": "Forest Therapy",
+      "Description": "Guided nature immersion that helps restore attention and calm the nervous system."
+    },
+    {
+      "Title": "Self-Myofascial Release",
+      "Description": "Simple body-based practices that help release stress patterns linked to screen-heavy life."
+    },
+    {
+      "Title": "Nature Journaling",
+      "Description": "Reflective observation practices that support creativity, presence, and curiosity."
+    },
+    {
+      "Title": "Collective Effervescence",
+      "Description": "Shared movement, music, and outdoor connection that renews group energy."
+    },
+    {
+      "Title": "Virtual Forest Bathing",
+      "Description": "An indoor option that brings calming, nature-based sensory cues into the room."
+    }
+  ]
+}

--- a/Upendo-Value-Props-List-Columns-Parallax/options.json
+++ b/Upendo-Value-Props-List-Columns-Parallax/options.json
@@ -1,0 +1,56 @@
+{
+  "fields": {
+    "ModuleTitle": {
+      "type": "text",
+      "helper": "Used by OpenContent to sync with the DNN module title. This does not display to site visitors.",
+      "placeholder": "Value Props - Two Column"
+    },
+    "ModuleAnchor": {
+      "type": "text",
+      "helper": "Optional. Use only letters, numbers, and hyphens if you want to link directly to this section from elsewhere on the page.",
+      "placeholder": "value-props",
+      "showMessages": false
+    },
+    "SectionHeading": {
+      "type": "text",
+      "helper": "Optional. Main heading shown above the two-column list. HTML is allowed.",
+      "placeholder": "Practices for Modern Vitality"
+    },
+    "IntroText": {
+      "type": "textarea",
+      "helper": "Optional. Short intro shown below the heading. HTML is allowed.",
+      "placeholder": "Science-backed practices that help people slow down, reconnect, and restore."
+    },
+    "BackgroundImage": {
+      "type": "image",
+      "uploadfolder": "Content/Value-Props/",
+      "typeahead": {
+        "Folder": "Content/Value-Props/"
+      },
+      "helper": "Optional. Wide landscape image used behind this section with a parallax-style effect. Recommended minimum: 1920 x 1080 px."
+    },
+    "ListIcon": {
+      "type": "text",
+      "placeholder": "fas fa-heart",
+      "helper": "Find icons at <a href=\"https://fontawesome.com/v5/search?ic=free-collection\" rel=\"noopener noreferrer\" target=\"_blank\">FontAwesome</a>. (Examples: <code>fas fa-heart</code>, <code>fas fa-leaf</code>, <code>fas fa-tree</code>, etc.)"
+    },
+    "ValueProps": {
+      "type": "accordion",
+      "helper": "Required. Add the list items in the order you want them displayed. If there is an odd number of items, the extra item will appear in the first column.",
+      "items": {
+        "fields": {
+          "Title": {
+            "type": "text",
+            "helper": "Required. Short title for this list item. HTML is allowed.",
+            "placeholder": "Forest Therapy"
+          },
+          "Description": {
+            "type": "text",
+            "helper": "Optional. Short supporting description. HTML is allowed.",
+            "placeholder": "Guided nature-based sessions that support attention recovery, stress relief, and reconnection."
+          }
+        }
+      }
+    }
+  }
+}

--- a/Upendo-Value-Props-List-Columns-Parallax/schema.json
+++ b/Upendo-Value-Props-List-Columns-Parallax/schema.json
@@ -1,0 +1,55 @@
+{
+  "type": "object",
+  "properties": {
+    "ModuleTitle": {
+      "type": "string",
+      "title": "Module Title"
+    },
+    "ModuleAnchor": {
+      "type": "string",
+      "title": "Module Anchor",
+      "pattern": "^$|^[a-zA-Z0-9\\-]+$"
+    },
+    "SectionHeading": {
+      "type": "string",
+      "title": "Section Heading"
+    },
+    "IntroText": {
+      "type": "string",
+      "title": "Intro Text"
+    },
+    "BackgroundImage": {
+      "type": "string",
+      "title": "Background Image"
+    },
+    "ListIcon": {
+      "type": "string",
+      "title": "List Icon"
+    },
+    "ValueProps": {
+      "type": "array",
+      "title": "Value Props",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "Title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description"
+          }
+        },
+        "required": [
+          "Title"
+        ]
+      }
+    }
+  },
+  "required": [
+    "ListIcon",
+    "ValueProps"
+  ]
+}

--- a/Upendo-Value-Props-List-Columns-Parallax/template-data.json
+++ b/Upendo-Value-Props-List-Columns-Parallax/template-data.json
@@ -1,0 +1,8 @@
+{
+  "BackgroundColorClass": "bg-body",
+  "MarginTop": "mt-5",
+  "MarginBottom": "mb-5",
+  "PaddingTop": "pt-5",
+  "PaddingBottom": "pb-5",
+  "BackgroundOverlayOpacity": "0.45"
+}

--- a/Upendo-Value-Props-List-Columns-Parallax/template-options.json
+++ b/Upendo-Value-Props-List-Columns-Parallax/template-options.json
@@ -1,0 +1,118 @@
+{
+  "fields": {
+    "BackgroundColorClass": {
+      "type": "select",
+      "helper": "Choose a built-in Bootstrap or project background color class for this section.",
+      "optionLabels": [
+        "None / Theme Default",
+        "Primary",
+        "Primary (theme)",
+        "Secondary",
+        "Secondary (theme)",
+        "Tertiary (theme)",
+        "Quaternary (theme)",
+        "H5 (theme)",
+        "H6 (theme)",
+        "Success",
+        "Danger",
+        "Warning",
+        "Info",
+        "Light",
+        "Dark",
+        "White",
+        "Body",
+        "Transparent",
+        "Primary Subtle",
+        "Secondary Subtle",
+        "Success Subtle",
+        "Danger Subtle",
+        "Warning Subtle",
+        "Info Subtle",
+        "Light Subtle",
+        "Dark Subtle",
+        "Off White",
+        "Warm White",
+        "Cream",
+        "Soft Beige",
+        "Sand",
+        "Light Sage",
+        "Sage",
+        "Pale Green",
+        "Mist",
+        "Soft Gray",
+        "Forest Green"
+      ],
+      "sort": true,
+      "removeDefaultNone": true
+    },
+    "MarginTop": {
+      "title": "Margin (top)",
+      "type": "select",
+      "optionLabels": [
+        "mt-0",
+        "mt-1",
+        "mt-2",
+        "mt-3",
+        "mt-4",
+        "mt-5",
+        "mt-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "MarginBottom": {
+      "title": "Margin (bottom)",
+      "type": "select",
+      "optionLabels": [
+        "mb-0",
+        "mb-1",
+        "mb-2",
+        "mb-3",
+        "mb-4",
+        "mb-5",
+        "mb-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "PaddingTop": {
+      "title": "Padding (top)",
+      "type": "select",
+      "optionLabels": [
+        "pt-0",
+        "pt-1",
+        "pt-2",
+        "pt-3",
+        "pt-4",
+        "pt-5",
+        "pt-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "PaddingBottom": {
+      "title": "Padding (bottom)",
+      "type": "select",
+      "optionLabels": [
+        "pb-0",
+        "pb-1",
+        "pb-2",
+        "pb-3",
+        "pb-4",
+        "pb-5",
+        "pb-auto"
+      ],
+      "removeDefaultNone": true
+    },
+    "BackgroundOverlayOpacity": {
+      "type": "select",
+      "helper": "Controls the dark overlay shown only when a background image is configured.",
+      "optionLabels": [
+        "None",
+        "15%",
+        "30%",
+        "45% (default)",
+        "60%",
+        "75%"
+      ],
+      "removeDefaultNone": true
+    }
+  }
+}

--- a/Upendo-Value-Props-List-Columns-Parallax/template-schema.json
+++ b/Upendo-Value-Props-List-Columns-Parallax/template-schema.json
@@ -1,0 +1,112 @@
+{
+  "type": "object",
+  "properties": {
+    "BackgroundColorClass": {
+      "type": "string",
+      "title": "Background Color",
+      "enum": [
+        "",
+        "bg-primary",
+        "bg-primary-scoped",
+        "bg-secondary",
+        "bg-secondary-scoped",
+        "bg-tertiary",
+        "bg-quaternary",
+        "bg-h5",
+        "bg-h6",
+        "bg-success",
+        "bg-danger",
+        "bg-warning",
+        "bg-info",
+        "bg-light",
+        "bg-dark",
+        "bg-white",
+        "bg-body",
+        "bg-transparent",
+        "bg-primary-subtle",
+        "bg-secondary-subtle",
+        "bg-success-subtle",
+        "bg-danger-subtle",
+        "bg-warning-subtle",
+        "bg-info-subtle",
+        "bg-light-subtle",
+        "bg-dark-subtle",
+        "bg-off-white",
+        "bg-warm-white",
+        "bg-cream",
+        "bg-soft-beige",
+        "bg-sand",
+        "bg-light-sage",
+        "bg-sage",
+        "bg-pale-green",
+        "bg-mist",
+        "bg-soft-gray",
+        "bg-forest-green"
+      ]
+    },
+    "MarginTop": {
+      "title": "Margin (top)",
+      "type": "string",
+      "enum": [
+        "mt-0",
+        "mt-1",
+        "mt-2",
+        "mt-3",
+        "mt-4",
+        "mt-5",
+        "mt-auto"
+      ]
+    },
+    "MarginBottom": {
+      "title": "Margin (bottom)",
+      "type": "string",
+      "enum": [
+        "mb-0",
+        "mb-1",
+        "mb-2",
+        "mb-3",
+        "mb-4",
+        "mb-5",
+        "mb-auto"
+      ]
+    },
+    "PaddingTop": {
+      "title": "Padding (top)",
+      "type": "string",
+      "enum": [
+        "pt-0",
+        "pt-1",
+        "pt-2",
+        "pt-3",
+        "pt-4",
+        "pt-5",
+        "pt-auto"
+      ]
+    },
+    "PaddingBottom": {
+      "title": "Padding (bottom)",
+      "type": "string",
+      "enum": [
+        "pb-0",
+        "pb-1",
+        "pb-2",
+        "pb-3",
+        "pb-4",
+        "pb-5",
+        "pb-auto"
+      ]
+    },
+    "BackgroundOverlayOpacity": {
+      "type": "string",
+      "title": "Background Overlay Opacity",
+      "enum": [
+        "0",
+        "0.15",
+        "0.3",
+        "0.45",
+        "0.6",
+        "0.75"
+      ]
+    }
+  }
+}

--- a/Upendo-Value-Props-List-Columns-Parallax/template.cshtml
+++ b/Upendo-Value-Props-List-Columns-Parallax/template.cshtml
@@ -1,0 +1,251 @@
+@using System
+@using System.Collections
+@using System.Web
+@using System.Web.Helpers
+@using Upendo.Libraries.RunsOnUpendoCore.Helpers
+@inherits Satrabel.OpenContent.Components.OpenContentWebPage
+
+@functions {
+    private static string GetImageUrl(dynamic image)
+    {
+        if (image == null)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            if (image.Url != null)
+            {
+                return Convert.ToString(image.Url);
+            }
+        }
+        catch
+        {
+        }
+
+        return Convert.ToString(image);
+    }
+}
+
+@{
+    TemplateHelper.HideAdminBorder(Model.Context.ModuleId, Model.Context.TabId);
+    RegisterStyleSheet("template.css");
+
+    var moduleAnchor = Model.ModuleAnchor != null ? Convert.ToString(Model.ModuleAnchor) : string.Empty;
+
+    var sectionHeading = Model.SectionHeading != null ? Convert.ToString(Model.SectionHeading) : string.Empty;
+    var introText = Model.IntroText != null ? Convert.ToString(Model.IntroText) : string.Empty;
+    var listIcon = Model.ListIcon != null ? Convert.ToString(Model.ListIcon) : string.Empty;
+    var backgroundImageUrl = GetImageUrl(Model.BackgroundImage);
+
+    var backgroundColorClass = Model.Settings != null && Model.Settings.BackgroundColorClass != null
+        ? Convert.ToString(Model.Settings.BackgroundColorClass)
+        : string.Empty;
+
+    var marginTop = Model.Settings != null && Model.Settings.MarginTop != null
+        ? Convert.ToString(Model.Settings.MarginTop)
+        : string.Empty;
+
+    var marginBottom = Model.Settings != null && Model.Settings.MarginBottom != null
+        ? Convert.ToString(Model.Settings.MarginBottom)
+        : string.Empty;
+
+    var paddingTop = Model.Settings != null && Model.Settings.PaddingTop != null
+        ? Convert.ToString(Model.Settings.PaddingTop)
+        : string.Empty;
+
+    var paddingBottom = Model.Settings != null && Model.Settings.PaddingBottom != null
+        ? Convert.ToString(Model.Settings.PaddingBottom)
+        : string.Empty;
+
+    var backgroundOverlayOpacity = Model.Settings != null && Model.Settings.BackgroundOverlayOpacity != null
+        ? Convert.ToString(Model.Settings.BackgroundOverlayOpacity)
+        : "0.45";
+
+    var hasBackgroundImage = !string.IsNullOrWhiteSpace(backgroundImageUrl);
+    var backgroundImageStyle = string.Empty;
+
+    if (hasBackgroundImage)
+    {
+        backgroundImageStyle = "background-image:url('" + HttpUtility.HtmlAttributeEncode(backgroundImageUrl.Replace("'", "%27")) + "');";
+    }
+
+    var sectionClass = "oc-value-props-parallax position-relative w-100";
+
+    if (hasBackgroundImage)
+    {
+        sectionClass += " oc-value-props-parallax--has-image";
+    }
+
+    if (!string.IsNullOrWhiteSpace(backgroundColorClass))
+    {
+        sectionClass += " " + backgroundColorClass;
+    }
+
+    if (!string.IsNullOrWhiteSpace(marginTop))
+    {
+        sectionClass += " " + marginTop;
+    }
+
+    if (!string.IsNullOrWhiteSpace(marginBottom))
+    {
+        sectionClass += " " + marginBottom;
+    }
+
+    if (!string.IsNullOrWhiteSpace(paddingTop))
+    {
+        sectionClass += " " + paddingTop;
+    }
+
+    if (!string.IsNullOrWhiteSpace(paddingBottom))
+    {
+        sectionClass += " " + paddingBottom;
+    }
+
+    var items = new ArrayList();
+
+    if (Model.ValueProps != null)
+    {
+        foreach (var item in Model.ValueProps)
+        {
+            items.Add(item);
+        }
+    }
+
+    var totalItems = items.Count;
+    var firstColumnCount = (int)Math.Ceiling(totalItems / 2.0);
+
+    var hasHeading = !string.IsNullOrWhiteSpace(sectionHeading);
+    var hasIntro = !string.IsNullOrWhiteSpace(introText);
+    var hasAnchor = !string.IsNullOrWhiteSpace(moduleAnchor);
+    var hasItems = totalItems > 0;
+
+    var sectionId = "oc-value-props-parallax-" + Model.Context.ModuleId;
+    var headingId = sectionId + "-heading";
+    var sectionAccessibilityAttribute = hasHeading ? "aria-labelledby=\"" + HttpUtility.HtmlAttributeEncode(headingId) + "\"" : string.Empty;
+
+    if (string.IsNullOrWhiteSpace(listIcon))
+    {
+        listIcon = "fas fa-check";
+    }
+}
+
+@if (hasAnchor)
+{
+    <div id="@moduleAnchor"></div>
+}
+
+@if (hasItems)
+{
+    <section class="@sectionClass" @Html.Raw(sectionAccessibilityAttribute)>
+        @if (hasBackgroundImage)
+        {
+            <div class="oc-vpp-background" style="@Html.Raw(backgroundImageStyle)" aria-hidden="true"></div>
+            <div class="oc-vpp-overlay" style="opacity:@backgroundOverlayOpacity;" aria-hidden="true"></div>
+        }
+
+        <div class="container-xxl oc-vpp-container">
+            <div class="row">
+                <div class="col-12">
+
+                    @if (hasHeading || hasIntro)
+                    {
+                        <div class="oc-vpp-header text-center mb-5">
+                            @if (hasHeading)
+                            {
+                                <h2 id="@headingId" class="oc-vpp-heading text-notransform mb-3">@Html.Raw(sectionHeading)</h2>
+                            }
+
+                            @if (hasIntro)
+                            {
+                                <div class="oc-vpp-intro mx-auto">
+                                    @Html.Raw(introText)
+                                </div>
+                            }
+                        </div>
+                    }
+
+                    <div class="row g-4 g-lg-5">
+                        <div class="col-12 col-md-6">
+                            <ul class="oc-vpp-list list-unstyled mb-0" role="list">
+                                @{
+                                    var delayIndexLeft = 1;
+                                }
+                                @for (var i = 0; i < firstColumnCount; i++)
+                                {
+                                    var item = items[i];
+                                    var itemJson = Json.Encode(item);
+                                    dynamic itemData = Json.Decode(itemJson);
+
+                                    var title = itemData != null && itemData.Title != null ? Convert.ToString(itemData.Title) : string.Empty;
+                                    var description = itemData != null && itemData.Description != null ? Convert.ToString(itemData.Description) : string.Empty;
+
+                                    delayIndexLeft++;
+                                    var animationDelay = Convert.ToString(delayIndexLeft * 200);
+
+                                    <li class="oc-vpp-item fadeInUp" data-appear-animation="fadeInUp" data-appear-animation-delay="@animationDelay">
+                                        <div class="oc-vpp-item-inner">
+                                            <div class="oc-vpp-icon-wrap" aria-hidden="true">
+                                                <i class="@listIcon oc-vpp-icon"></i>
+                                            </div>
+                                            <div class="oc-vpp-content">
+                                                <h5 class="oc-vpp-title text-notransform mt-2 mb-2">@Html.Raw(title)</h5>
+
+                                                @if (!string.IsNullOrWhiteSpace(description))
+                                                {
+                                                    <div class="oc-vpp-description text-small">
+                                                        @Html.Raw(description)
+                                                    </div>
+                                                }
+                                            </div>
+                                        </div>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+
+                        <div class="col-12 col-md-6">
+                            <ul class="oc-vpp-list list-unstyled mb-0" role="list">
+                                @{
+                                    var delayIndexRight = firstColumnCount;
+                                }
+                                @for (var i = firstColumnCount; i < totalItems; i++)
+                                {
+                                    var item = items[i];
+                                    var itemJson = Json.Encode(item);
+                                    dynamic itemData = Json.Decode(itemJson);
+
+                                    var title = itemData != null && itemData.Title != null ? Convert.ToString(itemData.Title) : string.Empty;
+                                    var description = itemData != null && itemData.Description != null ? Convert.ToString(itemData.Description) : string.Empty;
+
+                                    delayIndexRight++;
+                                    var animationDelay = Convert.ToString(delayIndexRight * 200);
+
+                                    <li class="oc-vpp-item fadeInUp" data-appear-animation="fadeInUp" data-appear-animation-delay="@animationDelay">
+                                        <div class="oc-vpp-item-inner">
+                                            <div class="oc-vpp-icon-wrap" aria-hidden="true">
+                                                <i class="@listIcon oc-vpp-icon"></i>
+                                            </div>
+                                            <div class="oc-vpp-content">
+                                                <h5 class="oc-vpp-title text-notransform mt-2 mb-2">@Html.Raw(title)</h5>
+
+                                                @if (!string.IsNullOrWhiteSpace(description))
+                                                {
+                                                    <div class="oc-vpp-description text-small">
+                                                        @Html.Raw(description)
+                                                    </div>
+                                                }
+                                            </div>
+                                        </div>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </section>
+}

--- a/Upendo-Value-Props-List-Columns-Parallax/template.css
+++ b/Upendo-Value-Props-List-Columns-Parallax/template.css
@@ -1,0 +1,276 @@
+.oc-value-props-parallax {
+    width: 100%;
+    overflow: hidden;
+    --oc-vpp-heading-color: inherit;
+    --oc-vpp-body-color: inherit;
+    --oc-vpp-icon-color: currentColor;
+    --oc-vpp-link-color: inherit;
+}
+
+.oc-value-props-parallax .oc-vpp-background,
+.oc-value-props-parallax .oc-vpp-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.oc-value-props-parallax .oc-vpp-background {
+    z-index: 0;
+    background-attachment: fixed;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+}
+
+.oc-value-props-parallax .oc-vpp-overlay {
+    z-index: 1;
+    background-color: #000000;
+}
+
+.oc-value-props-parallax .oc-vpp-container {
+    position: relative;
+    z-index: 2;
+}
+
+.oc-value-props-parallax .oc-vpp-header {
+    max-width: 56rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.oc-value-props-parallax .oc-vpp-heading {
+    margin: 0 0 1rem 0;
+    line-height: 1.15;
+    color: var(--oc-vpp-heading-color);
+}
+
+.oc-value-props-parallax .oc-vpp-intro {
+    max-width: 46rem;
+    color: var(--oc-vpp-body-color);
+}
+
+.oc-value-props-parallax .oc-vpp-intro > *:last-child {
+    margin-bottom: 0;
+}
+
+.oc-value-props-parallax .oc-vpp-intro a,
+.oc-value-props-parallax .oc-vpp-description a,
+.oc-value-props-parallax .oc-vpp-title a {
+    color: var(--oc-vpp-link-color);
+}
+
+.oc-value-props-parallax .oc-vpp-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.oc-value-props-parallax .oc-vpp-item {
+    opacity: 0;
+    transform: translate3d(0, 1rem, 0);
+    animation-name: ocValuePropsParallaxFadeInUp;
+    animation-duration: 0.9s;
+    animation-timing-function: ease-out;
+    animation-fill-mode: both;
+    will-change: opacity, transform;
+}
+
+.oc-value-props-parallax .oc-vpp-item-inner {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    width: 100%;
+}
+
+.oc-value-props-parallax .oc-vpp-icon-wrap {
+    flex: 0 0 auto;
+    width: 2.25rem;
+    min-width: 2.25rem;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 0.35rem;
+    line-height: 1;
+    color: var(--oc-vpp-icon-color);
+}
+
+.oc-value-props-parallax .oc-vpp-icon {
+    font-size: 1.5rem;
+    line-height: 1;
+    color: inherit;
+}
+
+.oc-value-props-parallax .oc-vpp-content {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.oc-value-props-parallax .oc-vpp-title {
+    line-height: 1.35;
+    color: var(--oc-vpp-heading-color);
+}
+
+.oc-value-props-parallax .oc-vpp-description {
+    color: var(--oc-vpp-body-color);
+}
+
+.oc-value-props-parallax .oc-vpp-description > *:last-child,
+.oc-value-props-parallax .oc-vpp-description:last-child {
+    margin-bottom: 0;
+}
+
+@keyframes ocValuePropsParallaxFadeInUp {
+    from {
+        opacity: 0;
+        transform: translate3d(0, 1rem, 0);
+    }
+    to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+    }
+}
+
+@media (max-width: 767.98px) {
+    .oc-value-props-parallax .oc-vpp-background {
+        background-attachment: scroll;
+    }
+
+    .oc-value-props-parallax .oc-vpp-list {
+        gap: 1.25rem;
+    }
+
+    .oc-value-props-parallax .oc-vpp-item-inner {
+        gap: 0.875rem;
+    }
+
+    .oc-value-props-parallax .oc-vpp-icon-wrap {
+        width: 2rem;
+        min-width: 2rem;
+        padding-top: 0.3rem;
+    }
+
+    .oc-value-props-parallax .oc-vpp-icon {
+        font-size: 1.35rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .oc-value-props-parallax .oc-vpp-background {
+        background-attachment: scroll;
+    }
+
+    .oc-value-props-parallax .oc-vpp-item {
+        opacity: 1;
+        transform: none;
+        animation: none;
+        will-change: auto;
+    }
+}
+
+/* Dark background contrast handling */
+.oc-value-props-parallax.bg-primary,
+.oc-value-props-parallax.bg-primary-scoped,
+.oc-value-props-parallax.bg-secondary,
+.oc-value-props-parallax.bg-secondary-scoped,
+.oc-value-props-parallax.bg-tertiary,
+.oc-value-props-parallax.bg-quaternary,
+.oc-value-props-parallax.bg-h5,
+.oc-value-props-parallax.bg-h6,
+.oc-value-props-parallax.bg-success,
+.oc-value-props-parallax.bg-danger,
+.oc-value-props-parallax.bg-dark,
+.oc-value-props-parallax.bg-forest-green {
+    --oc-vpp-heading-color: #ffffff;
+    --oc-vpp-body-color: rgba(255, 255, 255, 0.88);
+    --oc-vpp-icon-color: #ffffff;
+    --oc-vpp-link-color: #ffffff;
+}
+
+/* Light background defaults */
+.oc-value-props-parallax.bg-light,
+.oc-value-props-parallax.bg-white,
+.oc-value-props-parallax.bg-body,
+.oc-value-props-parallax.bg-transparent,
+.oc-value-props-parallax.bg-primary-subtle,
+.oc-value-props-parallax.bg-secondary-subtle,
+.oc-value-props-parallax.bg-success-subtle,
+.oc-value-props-parallax.bg-danger-subtle,
+.oc-value-props-parallax.bg-warning-subtle,
+.oc-value-props-parallax.bg-info-subtle,
+.oc-value-props-parallax.bg-light-subtle,
+.oc-value-props-parallax.bg-dark-subtle,
+.oc-value-props-parallax.bg-off-white,
+.oc-value-props-parallax.bg-warm-white,
+.oc-value-props-parallax.bg-cream,
+.oc-value-props-parallax.bg-soft-beige,
+.oc-value-props-parallax.bg-sand,
+.oc-value-props-parallax.bg-light-sage,
+.oc-value-props-parallax.bg-sage,
+.oc-value-props-parallax.bg-pale-green,
+.oc-value-props-parallax.bg-mist,
+.oc-value-props-parallax.bg-soft-gray {
+    --oc-vpp-heading-color: inherit;
+    --oc-vpp-body-color: inherit;
+    --oc-vpp-icon-color: currentColor;
+    --oc-vpp-link-color: inherit;
+}
+
+.oc-value-props-parallax.oc-value-props-parallax--has-image {
+    --oc-vpp-heading-color: #ffffff;
+    --oc-vpp-body-color: rgba(255, 255, 255, 0.88);
+    --oc-vpp-icon-color: #ffffff;
+    --oc-vpp-link-color: #ffffff;
+}
+
+.oc-value-props-parallax.oc-value-props-parallax--has-image .oc-vpp-container {
+    text-shadow:
+        0 2px 4px rgba(0, 0, 0, 1),
+        0 6px 12px rgba(0, 0, 0, 0.95),
+        0 12px 24px rgba(0, 0, 0, 0.90),
+        0 25px 50px rgba(0, 0, 0, 0.80);
+}
+
+/* Custom background colors */
+.oc-value-props-parallax.bg-off-white {
+    background-color: #faf9f6 !important;
+}
+
+.oc-value-props-parallax.bg-warm-white {
+    background-color: #f7f5f0 !important;
+}
+
+.oc-value-props-parallax.bg-cream {
+    background-color: #f3eee4 !important;
+}
+
+.oc-value-props-parallax.bg-soft-beige {
+    background-color: #e9dfcf !important;
+}
+
+.oc-value-props-parallax.bg-sand {
+    background-color: #ddd0bc !important;
+}
+
+.oc-value-props-parallax.bg-light-sage {
+    background-color: #dfe8dc !important;
+}
+
+.oc-value-props-parallax.bg-sage {
+    background-color: #c7d3c1 !important;
+}
+
+.oc-value-props-parallax.bg-pale-green {
+    background-color: #e9eee8 !important;
+}
+
+.oc-value-props-parallax.bg-mist {
+    background-color: #eef2ee !important;
+}
+
+.oc-value-props-parallax.bg-soft-gray {
+    background-color: #ebeef3 !important;
+}
+
+.oc-value-props-parallax.bg-forest-green {
+    background-color: #143d2d !important;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #

## Description
<!--- Describe your changes in detail -->
Adds a new `Upendo-Value-Props-List-Columns-Parallax` OpenContent template.

This template provides a two-column value props list with:
- optional parallax-style background image
- configurable background overlay opacity
- Bootstrap/project spacing and background class options
- sample content and schema/admin configuration
- scoped CSS with mobile and reduced-motion handling
- accessible section labeling behavior
- safe fallback icon handling


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Reviewed the new template files locally and compared the structure against the existing `Upendo-Value-Props-List-Columns` template.

Validated JSON syntax for:
- `data.json`
- `options.json`
- `schema.json`
- `template-data.json`
- `template-options.json`
- `template-schema.json`


## Screenshots (if appropriate):
<img width="1824" height="683" alt="image" src="https://github.com/user-attachments/assets/d0024e89-e13f-4b71-97d4-5eba9e7d0c58" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.